### PR TITLE
Add fills

### DIFF
--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -58,13 +58,19 @@ case class WeightedAveragePricing(weight: Double) extends DiscriminatoryPricingR
 }
 
 
+case class Fill(askOrder: LimitAskOrder, bidOrder: LimitBidOrder, price: Price) {
+
+  val quantity: Quantity = Quantity(math.min(askOrder.quantity.value, bidOrder.quantity.value))
+
+}
+
 // example of buyer's bid (or M+1 price rule)...incentive compatible for the seller!
-pairedOrders.map(WeightedAveragePricing(1.0)).toList
+pairedOrders map { case (askOrder, bidOrder) => Fill(askOrder, bidOrder, WeightedAveragePricing(1.0)((askOrder, bidOrder))) }
 
 
 // example of seller's ask (or M price rule)...incentive compatible for the buyer
-pairedOrders.map(WeightedAveragePricing(0.0)).toList
+pairedOrders map { case (askOrder, bidOrder) => Fill(askOrder, bidOrder, WeightedAveragePricing(0.0)((askOrder, bidOrder))) }
 
 
 // split the trade surplus evenly...not incentive compatible!
-pairedOrders.map(WeightedAveragePricing(0.5)).toList
+pairedOrders map { case (askOrder, bidOrder) => Fill(askOrder, bidOrder, WeightedAveragePricing(0.5)((askOrder, bidOrder))) }

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -1,9 +1,9 @@
 import java.util.UUID
 
 import org.economicsl.auctions._
-import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
+import org.economicsl.auctions.singleunit.Fill
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
-import org.economicsl.auctions.singleunit.pricing.{BuyersBidPricingRule, SellersAskPricingRule, WeightedAveragePricingRule}
+import org.economicsl.auctions.singleunit.pricing.{BuyersBidPricingRule, PricingRule, SellersAskPricingRule, WeightedAveragePricingRule}
 
 
 /** Example `Tradable` object. */
@@ -62,13 +62,6 @@ val askPriceQuote = buyersBidPricing(orderBook5)
 val sellersAskPricing = new SellersAskPricingRule[Google]()
 val bidPriceQuote = sellersAskPricing(orderBook5)
 
-
-case class Fill[T <: Tradable](askOrder: LimitAskOrder[T], bidOrder: LimitBidOrder[T], price: Price) {
-
-  val quantity: Quantity = Quantity(math.min(askOrder.quantity.value, bidOrder.quantity.value))
-
-}
-
 // example of a uniform price auction that would be incentive compatible for the sellers...
 val averagePricing = WeightedAveragePricingRule[Google](0.5)
 val averagePrice = averagePricing(orderBook5)
@@ -76,3 +69,8 @@ val averagePrice = averagePricing(orderBook5)
 // take a look at paired orders
 val (pairedOrders, _) = orderBook5.takeWhileMatched
 pairedOrders.toList
+
+
+def fill[T <: Tradable](pricingRule: PricingRule[T, Price])(orderBook: FourHeapOrderBook[T]): Option[(Fill[T], FourHeapOrderBook[T])] = {
+  pricingRule(orderBook).map{ price => val (askOrder, bidOrder) = orderBook.head; Some(Fill(askOrder, bidOrder, price), orderBook.tail) }
+}

--- a/src/main/scala/org/economicsl/auctions/singleunit/Fill.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Fill.scala
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 EconomicSL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.auctions.singleunit
+
+import org.economicsl.auctions.{Price, Quantity, Tradable}
+
+
+case class Fill[T <: Tradable](askOrder: LimitAskOrder[T], bidOrder: LimitBidOrder[T], price: Price) {
+
+  val quantity: Quantity = Quantity(math.min(askOrder.quantity.value, bidOrder.quantity.value))
+
+}

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
@@ -19,7 +19,7 @@ import org.economicsl.auctions.{Price, Tradable}
 import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 
 
-class FourHeapOrderBook[T <: Tradable] private(val matchedOrders: MatchedOrders[T], unMatchedOrders: UnMatchedOrders[T]) {
+class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], unMatchedOrders: UnMatchedOrders[T]) {
 
   // value of lowest matched bid must exceed value of highest unmatched bid!
   require(matchedOrders.bidOrders.headOption.forall(b1 => unMatchedOrders.bidOrders.headOption.forall(b2 => b1.value >= b2.value)))


### PR DESCRIPTION
@bherd This PR add a `Fill` class that is used to represent a matched pair of ask and bid orders and a particular transaction price.  and quantity.  A yet to be defined auction mechanism processes ask and bid orders and generates `Fill` instances.  The generated `Fill` instances will be sent to a settlement mechanism which would handle the exchange of resources (i.e., goods for money).  