### PR TITLE
Added a Divisible mixin trait

### DIFF
--- a/src/main/scala/org/economicsl/auctions/Divisible.scala
+++ b/src/main/scala/org/economicsl/auctions/Divisible.scala
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 EconomicSL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.auctions
+
+
+/** Mixin trait providing behavior necessary to split an order into two orders. */
+trait Divisible[+T <: Tradable, O <: Order[T] with SinglePricePoint[T] with Divisible[T, O]] {
+  this: Order[T] with SinglePricePoint[T] =>
+
+  def split(residual: Quantity): (O, O)
+
+}

--- a/src/main/scala/org/economicsl/auctions/multiunit/Divisible.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/Divisible.scala
@@ -13,13 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package org.economicsl.auctions
+package org.economicsl.auctions.multiunit
+
+import org.economicsl.auctions.{Order, Quantity, Tradable}
 
 
 /** Mixin trait providing behavior necessary to split an order into two orders. */
-trait Divisible[+T <: Tradable, O <: Order[T] with SinglePricePoint[T] with Divisible[T, O]] {
+trait Divisible[+T <: Tradable, +O <: Order[T] with SinglePricePoint[T] with Divisible[T, O]] {
   this: Order[T] with SinglePricePoint[T] =>
 
-  def split(residual: Quantity): (O, O)
+  def withQuantity(residual: Quantity): O
 
 }

--- a/src/main/scala/org/economicsl/auctions/multiunit/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/LimitAskOrder.scala
@@ -20,8 +20,8 @@ import java.util.UUID
 import org.economicsl.auctions.{AskOrder, Price, Quantity, Tradable}
 
 
-/** Base trait for a limit order to sell some `Tradable`. */
-trait LimitAskOrder[+T <: Tradable] extends AskOrder[T] with SinglePricePoint[T]
+/** Base trait for a multi-unit limit order to sell some `Tradable`. */
+trait LimitAskOrder[+T <: Tradable] extends AskOrder[T] with SinglePricePoint[T] with Divisible[T, LimitAskOrder[T]]
 
 
 /** Companion object for `LimitAskOrder`.
@@ -37,7 +37,14 @@ object LimitAskOrder {
   }
 
   private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T)
-    extends LimitAskOrder[T]
+    extends LimitAskOrder[T] {
+
+    def withQuantity(residual: Quantity): LimitAskOrder[T] = {
+      require(residual.value < quantity.value)
+      copy(quantity = residual)
+    }
+
+  }
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/multiunit/LimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/LimitBidOrder.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import org.economicsl.auctions.{BidOrder, Price, Quantity, Tradable}
 
 /** Base trait for a limit order to buy some `Tradable`. */
-trait LimitBidOrder[+T <: Tradable] extends BidOrder[T] with SinglePricePoint[T]
+trait LimitBidOrder[+T <: Tradable] extends BidOrder[T] with SinglePricePoint[T] with Divisible[T, LimitBidOrder[T]]
 
 
 /** Companion object for `LimitBidOrder`.
@@ -36,7 +36,14 @@ object LimitBidOrder {
   }
 
   private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T)
-    extends LimitBidOrder[T]
+    extends LimitBidOrder[T] {
+
+    def withQuantity(residual: Quantity): LimitBidOrder[T] = {
+      require(residual.value < quantity.value)
+      copy(quantity = residual)
+    }
+
+  }
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/multiunit/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/MarketAskOrder.scala
@@ -28,6 +28,7 @@ trait MarketAskOrder[+T <: Tradable] extends LimitAskOrder[T] {
 
 }
 
+
 /** Companion object for `MarketAskOrder`.
   *
   * Provides constructor for default implementation of `MarketAskOrder` trait.
@@ -39,7 +40,14 @@ object MarketAskOrder {
   }
 
   private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, quantity: Quantity, tradable: T)
-    extends MarketAskOrder[T]
+    extends MarketAskOrder[T] {
+
+    def withQuantity(residual: Quantity): MarketAskOrder[T] = {
+      require(residual.value < quantity.value)
+      copy(quantity = residual)
+    }
+
+  }
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/multiunit/MarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/MarketBidOrder.scala
@@ -28,6 +28,7 @@ trait MarketBidOrder[+T <: Tradable] extends LimitBidOrder[T] {
 
 }
 
+
 /** Companion object for `MarketBidOrder`.
   *
   * Provides constructor for default implementation of `MarketBidOrder` trait.
@@ -39,6 +40,13 @@ object MarketBidOrder {
   }
 
   private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, quantity: Quantity, tradable: T)
-    extends MarketBidOrder[T]
+    extends MarketBidOrder[T] {
+
+    def withQuantity(residual: Quantity): MarketBidOrder[T] = {
+      require(residual.value < quantity.value)
+      copy(quantity = residual)
+    }
+
+  }
 
 }

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -54,3 +54,22 @@ val orderBook5 = orderBook4 + order8
 // take a look at paired orders
 val (pairedOrders, _) = orderBook5.takeWhileMatched
 pairedOrders.toList
+
+
+// Why can this not be made covariant in T? Can divisible orders be constructed using an auxiliary constructor on LimitAskOrder?
+case class DivisibleLimitAskOrder[T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T) extends
+  LimitAskOrder[T] with Divisible[T, DivisibleLimitAskOrder[T]] {
+
+  def split(residual: Quantity): (DivisibleLimitAskOrder[T], DivisibleLimitAskOrder[T]) = {
+    val remaining = Quantity(quantity.value - residual.value)
+    (this.copy(quantity = remaining), this.copy(quantity = residual))
+  }
+
+}
+
+
+// usage example for a divisible order
+val divisibleOrder: DivisibleLimitAskOrder[Google] = DivisibleLimitAskOrder(issuer, Price(9.56), Quantity(3), google)
+val(filled, residual) = divisibleOrder.split(Quantity(2))
+filled.quantity
+residual.quantity

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -55,22 +55,6 @@ val orderBook5 = orderBook4 + order8
 val (pairedOrders, _) = orderBook5.takeWhileMatched
 pairedOrders.toList
 
-
-// Why can this not be made covariant in T? Can divisible orders be constructed using an auxiliary constructor on LimitAskOrder?
-case class DivisibleLimitAskOrder[T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T) extends
-  LimitAskOrder[T] with Divisible[T, DivisibleLimitAskOrder[T]] {
-
-  def split(residual: Quantity): (DivisibleLimitAskOrder[T], DivisibleLimitAskOrder[T]) = {
-    require(residual.value < this.quantity.value)  // can this be check be lifted into the type system?
-    val remaining = Quantity(quantity.value - residual.value)
-    (this.copy(quantity = remaining), this.copy(quantity = residual))
-  }
-
-}
-
-
-// usage example for a divisible order
-val divisibleOrder: DivisibleLimitAskOrder[Google] = DivisibleLimitAskOrder(issuer, Price(9.56), Quantity(3), google)
-val(filled, residual) = divisibleOrder.split(Quantity(2))
-filled.quantity
+// currently all multi-unit orders are divisible...
+val residual = order7.withQuantity(Quantity(2))
 residual.quantity

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -61,6 +61,7 @@ case class DivisibleLimitAskOrder[T <: Tradable](issuer: UUID, limit: Price, qua
   LimitAskOrder[T] with Divisible[T, DivisibleLimitAskOrder[T]] {
 
   def split(residual: Quantity): (DivisibleLimitAskOrder[T], DivisibleLimitAskOrder[T]) = {
+    require(residual.value < this.quantity.value)  // can this be check be lifted into the type system?
     val remaining = Quantity(quantity.value - residual.value)
     (this.copy(quantity = remaining), this.copy(quantity = residual))
   }


### PR DESCRIPTION
@bherd-rb this PR adds a Divisible trait that can be mixed in to provide a split method for splitting orders into two separate orders.  Splitting an order is necessary for a multi-unit implementation of the `FourHeapOrder` book from Wellman.