### PR TITLE
Add value field

### DIFF
--- a/src/main/scala/org/economicsl/auctions/multiunit/SinglePricePoint.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/SinglePricePoint.scala
@@ -35,6 +35,9 @@ trait SinglePricePoint[+T <: Tradable] extends PriceQuantitySchedule[T] {
 
   val schedule: immutable.Map[Price, Quantity] = immutable.Map(limit -> quantity)
 
+  /** The total value of the order */
+  val value: Currency = limit.value * quantity.value
+
 }
 
 

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -15,6 +15,7 @@ class Apple extends Security
 val issuer = UUID.randomUUID()
 val google = new Google()
 val order1: multiunit.LimitAskOrder[Google] = multiunit.LimitAskOrder(issuer, Price(10), Quantity(100), google)
+order1.value
 
 // Create a multi-unit market ask order...
 val order2: multiunit.MarketAskOrder[Google] = multiunit.MarketAskOrder(issuer, Quantity(100), google)

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
@@ -21,6 +21,9 @@ import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 
 class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], unMatchedOrders: UnMatchedOrders[T]) {
 
+  require(matchedOrders.bidOrders.headOption.forall(bidOrder => bidOrder.value >= unMatchedOrders.bidOrders.head.value))  // value of lowest bid must exceed value of highest ask!
+  require(unMatchedOrders.askOrders.headOption.forall(askOrder => askOrder.value >= matchedOrders.askOrders.head.value))
+
   def - (order: LimitAskOrder[T]): FourHeapOrderBook[T] = {
     if (unMatchedOrders.contains(order)) {
       new FourHeapOrderBook(matchedOrders, unMatchedOrders - order)

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
@@ -21,8 +21,10 @@ import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 
 class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], unMatchedOrders: UnMatchedOrders[T]) {
 
-  require(matchedOrders.bidOrders.headOption.forall(bidOrder => bidOrder.value >= unMatchedOrders.bidOrders.head.value))  // value of lowest bid must exceed value of highest ask!
-  require(unMatchedOrders.askOrders.headOption.forall(askOrder => askOrder.value >= matchedOrders.askOrders.head.value))
+  // value of lowest matched bid must exceed value of highest unmatched bid!
+  require(matchedOrders.bidOrders.headOption.forall(b1 => unMatchedOrders.bidOrders.headOption.forall(b2 => b1.value >= b2.value)))
+  // value of lowest unmatched ask must exceed value of highest matched ask!
+  require(unMatchedOrders.askOrders.headOption.forall(a1 => matchedOrders.askOrders.headOption.forall(a2 => a1.value >= a2.value)))
 
   def - (order: LimitAskOrder[T]): FourHeapOrderBook[T] = {
     if (unMatchedOrders.contains(order)) {

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
@@ -22,7 +22,7 @@ import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 private[orderbooks] class MatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrders[T], val bidOrders: SortedBidOrders[T]) {
 
   require(askOrders.numberUnits == bidOrders.numberUnits)  // number of units must be the same!
-  require(bidOrders.headOption.forall(bidOrder => bidOrder.value >= askOrders.head.value))  // value of lowest bid must exceed value of highest ask!
+  require(bidOrders.headOption.forall(bidOrder => askOrders.headOption.forall(askOrder => bidOrder.value >= askOrder.value)))  // value of lowest bid must exceed value of highest ask!
 
   def + (orders: (LimitAskOrder[T], LimitBidOrder[T])): MatchedOrders[T] = {
     new MatchedOrders(askOrders + orders._1, bidOrders + orders._2)

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
@@ -22,7 +22,7 @@ import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 private[orderbooks] class MatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrders[T], val bidOrders: SortedBidOrders[T]) {
 
   require(askOrders.numberUnits == bidOrders.numberUnits)  // number of units must be the same!
-  require(bidOrders.headOption.forall(bidOrder => bidOrder.limit >= askOrders.head.limit))  // value of lowest bid must exceed value of highest ask!
+  require(bidOrders.headOption.forall(bidOrder => bidOrder.value >= askOrders.head.value))  // value of lowest bid must exceed value of highest ask!
 
   def + (orders: (LimitAskOrder[T], LimitBidOrder[T])): MatchedOrders[T] = {
     new MatchedOrders(askOrders + orders._1, bidOrders + orders._2)

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
@@ -21,7 +21,7 @@ import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 
 private[orderbooks] class UnMatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrders[T], val bidOrders: SortedBidOrders[T]) {
 
-  require(bidOrders.headOption.forall(bidOrder => bidOrder.limit <= askOrders.head.limit))
+  require(bidOrders.headOption.forall(bidOrder => bidOrder.value <= askOrders.head.value))
 
   def + (order: LimitAskOrder[T]): UnMatchedOrders[T] = new UnMatchedOrders(askOrders + order, bidOrders)
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
@@ -21,7 +21,8 @@ import org.economicsl.auctions.singleunit.{LimitAskOrder, LimitBidOrder}
 
 private[orderbooks] class UnMatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrders[T], val bidOrders: SortedBidOrders[T]) {
 
-  require(bidOrders.headOption.forall(bidOrder => bidOrder.value <= askOrders.head.value))
+  // highest bid order value must not exceed the lowest ask order value!
+  require(bidOrders.headOption.forall(bidOrder => askOrders.headOption.forall(askOrder => bidOrder.value <= askOrder.value)))
 
   def + (order: LimitAskOrder[T]): UnMatchedOrders[T] = new UnMatchedOrders(askOrders + order, bidOrders)
 


### PR DESCRIPTION
@bherd-rb This PR adds a `value` field to `SinglePricePoint` orders.  The value of an order is just the price times the quantity and is used to impose the constraints discussed in the Wurman et al (1998) paper on page 24.