### PR TITLE
First draft of price quote language.

### DIFF
--- a/src/main/scala/org/economicsl/auctions/quotes/PriceQuote.scala
+++ b/src/main/scala/org/economicsl/auctions/quotes/PriceQuote.scala
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 EconomicSL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.auctions.quotes
+
+import org.economicsl.auctions.Price
+
+
+sealed trait PriceQuote {
+
+  def quote: Price
+
+}
+
+case class AskPriceQuote(quote: Price) extends PriceQuote
+
+case class BidPriceQuote(quote: Price) extends PriceQuote
+
+case class BidAskSpreadQuote(quote: Price) extends PriceQuote

--- a/src/main/scala/org/economicsl/auctions/quotes/QuoteRequest.scala
+++ b/src/main/scala/org/economicsl/auctions/quotes/QuoteRequest.scala
@@ -1,0 +1,26 @@
+/*
+Copyright 2017 EconomicSL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.auctions.quotes
+
+
+sealed trait QuoteRequest
+
+
+object AskPriceQuoteRequest extends QuoteRequest
+
+object BidPriceQuoteRequest extends QuoteRequest
+
+object BidAskSpreadQuoteRequest extends QuoteRequest

--- a/src/main/scala/org/economicsl/auctions/singleunit/DoubleAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/DoubleAuction.scala
@@ -20,7 +20,7 @@ import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing.PricingRule
 
 
-class DoubleAuction[T <: Tradable] private(orderBook: FourHeapOrderBook[T]) {
+class DoubleAuction[T <: Tradable] private(protected val orderBook: FourHeapOrderBook[T]) {
 
   def insert(order: LimitAskOrder[T]): DoubleAuction[T] = {
     new DoubleAuction(orderBook + order)

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
@@ -84,6 +84,10 @@ class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], 
     case _ => None
   }
 
+  val spread: Option[Price] = {
+    bidPriceQuote.flatMap(p1 => askPriceQuote.map(p2 => Price(p2.value - p1.value)))
+  }
+
   def takeWhileMatched: (Stream[(LimitAskOrder[T], LimitBidOrder[T])], FourHeapOrderBook[T]) = {
     (matchedOrders.zipped, withEmptyMatchedOrders)
   }

--- a/src/main/scala/org/economicsl/auctions/singleunit/quotes/PriceQuotePolicy.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/quotes/PriceQuotePolicy.scala
@@ -1,0 +1,32 @@
+/*
+Copyright 2017 EconomicSL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.auctions.singleunit.quotes
+
+import org.economicsl.auctions.Tradable
+import org.economicsl.auctions.quotes._
+import org.economicsl.auctions.singleunit.DoubleAuction
+
+
+trait PriceQuotePolicy[T <: Tradable] {
+  this: DoubleAuction[T] =>
+
+  def quotePolicy: PartialFunction[QuoteRequest, Option[PriceQuote]] = {
+    case AskPriceQuoteRequest => orderBook.askPriceQuote.map(quote => AskPriceQuote(quote))
+    case BidPriceQuoteRequest => orderBook.bidPriceQuote.map(quote => BidPriceQuote(quote))
+    case BidAskSpreadQuoteRequest => orderBook.spread.map(quote => BidAskSpreadQuote(quote))
+  }
+
+}


### PR DESCRIPTION
@bherd-rb and @rafabap This PR adds a price quote policy to the API.  The basic idea is to define a mixin trait called `PriceQuotePolicy` that defines a partial function that takes quote requests as inputs and returns price quotes as outputs.

```scala
trait PriceQuotePolicy[T <: Tradable] {
  this: Auction[T] =>

    def quotePolicy: PartialFunction[QuoteRequest, Option[PriceQuote]] = {
      case AskPriceQuoteRequest => orderBook.askPriceQuote.map(quote => AskPriceQuote(quote))
      case BidPriceQuoteRequest => orderBook.bidPriceQuote.map(quote => BidPriceQuote(quote))
      case BidAskSpreadQuoteRequest => orderBook.spread.map(quote => BidAskSpreadQuote(quote))
    }

}
```

Anyway just wanted to get some ideas down on paper...