### PR TITLE
Discrete prices quantities

### DIFF
--- a/src/main/java/org/economicsl/auctions/singleunit/JDoubleAuctionTest.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JDoubleAuctionTest.java
@@ -27,12 +27,12 @@ public class JDoubleAuctionTest {
                 LimitAskOrder$.MODULE$.<LimitAskOrder<Service>>ordering(),
                 LimitBidOrder$.MODULE$.<LimitBidOrder<Service>>ordering().reverse());
 
-        LimitBidOrder<Service> bid1 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 10.0, new Service());
-        LimitAskOrder<Service> ask1 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 5.0, new Service());
+        LimitBidOrder<Service> bid1 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 10, new Service());
+        LimitAskOrder<Service> ask1 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 5, new Service());
         auction = auction.insert(bid1);
         auction = auction.insert(ask1);
-        LimitBidOrder<Service> bid2 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 3.0, new Service());
-        LimitAskOrder<Service> ask2 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 12.0, new Service());
+        LimitBidOrder<Service> bid2 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 3, new Service());
+        LimitAskOrder<Service> ask2 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 12, new Service());
         auction = auction.insert(bid2);
         auction = auction.insert(ask2);
         Optional<JDoubleAuction<Service>.ClearResult<Service>> clear = auction.clear(new WeightedAveragePricingRule<Service>(1.0));

--- a/src/main/java/org/economicsl/auctions/singleunit/OrderBookTest.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/OrderBookTest.java
@@ -33,8 +33,8 @@ public class OrderBookTest {
 
         Service service = new Service();
 
-        LimitBidOrder<Service> bid1 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 5.0, service);
-        LimitAskOrder<Service> ask1 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 5.0, service);
+        LimitBidOrder<Service> bid1 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 5, service);
+        LimitAskOrder<Service> ask1 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 5, service);
 
         orderbook = orderbook.$plus(bid1);
         orderbook = orderbook.$plus(ask1);

--- a/src/main/scala/org/economicsl/auctions/Price.scala
+++ b/src/main/scala/org/economicsl/auctions/Price.scala
@@ -34,11 +34,9 @@ object Price {
 
   implicit def mkOrderingOps(lhs: Price): PriceOrdering.Ops = PriceOrdering.mkOrderingOps(lhs)
 
-  val MaxValue = Price(Double.MaxValue)  // todo this number might be hardware specific?
+  val MaxValue = Price(Long.MaxValue)
 
-  val MinValue = Price(0.0)
-
-  val MinPositiveValue = Price(Double.MinPositiveValue)  // todo this number might be hardware specific?
+  val MinValue = Price(0)  // this is not restricting quantities to be non-negative!
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/Quantity.scala
+++ b/src/main/scala/org/economicsl/auctions/Quantity.scala
@@ -17,7 +17,7 @@ package org.economicsl.auctions
 
 
 /** Value class representing quantities. */
-case class Quantity(value: Double) extends AnyVal {
+case class Quantity(value: Long) extends AnyVal {
 
   def + (that: Quantity): Quantity = {
     Quantity(value + that.value)

--- a/src/main/scala/org/economicsl/auctions/multiunit/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/MarketAskOrder.scala
@@ -24,7 +24,7 @@ import org.economicsl.auctions.{Price, Quantity, Tradable}
 trait MarketAskOrder[+T <: Tradable] extends LimitAskOrder[T] {
 
   /** An issuer of a `MarketAskOrder` is willing to sell at any strictly positive price. */
-  val limit: Price = Price.MinPositiveValue
+  val limit: Price = Price.MinValue
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/package.scala
+++ b/src/main/scala/org/economicsl/auctions/package.scala
@@ -20,6 +20,6 @@ package org.economicsl
 package object auctions {
 
   /** Type used to representing currencies. */
-  type Currency = Double  // todo should this be Long or Double?
+  type Currency = Long
 
 }

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -23,8 +23,8 @@ order1.value
 val order2: multiunit.MarketAskOrder[Google] = multiunit.MarketAskOrder(issuer, Quantity(100), google)
 
 // Create some single-unit limit ask orders...
-val order3: singleunit.LimitAskOrder[Google] = singleunit.LimitAskOrder(issuer, Price(5.0), google)
-val order4: singleunit.LimitAskOrder[Google] = singleunit.LimitAskOrder(issuer, Price(6.0), google)
+val order3: singleunit.LimitAskOrder[Google] = singleunit.LimitAskOrder(issuer, Price(5), google)
+val order4: singleunit.LimitAskOrder[Google] = singleunit.LimitAskOrder(issuer, Price(6), google)
 
 // Create a multi-unit limit bid order...
 val order5: multiunit.LimitBidOrder[Google] = multiunit.LimitBidOrder(issuer, Price(10), Quantity(100), google)
@@ -33,12 +33,12 @@ val order5: multiunit.LimitBidOrder[Google] = multiunit.LimitBidOrder(issuer, Pr
 val order7: multiunit.MarketBidOrder[Google] = multiunit.MarketBidOrder(issuer, Quantity(100), google)
 
 // Create some single-unit limit bid orders...
-val order8: singleunit.LimitBidOrder[Google] = singleunit.LimitBidOrder(issuer, Price(10.0), google)
-val order9: singleunit.LimitBidOrder[Google] = singleunit.LimitBidOrder(issuer, Price(6.0), google)
+val order8: singleunit.LimitBidOrder[Google] = singleunit.LimitBidOrder(issuer, Price(10), google)
+val order9: singleunit.LimitBidOrder[Google] = singleunit.LimitBidOrder(issuer, Price(6), google)
 
 // Create an order for some other tradable
 val apple = new Apple()
-val order10: singleunit.LimitBidOrder[Apple] = singleunit.LimitBidOrder(issuer, Price(55.9), apple)
+val order10: singleunit.LimitBidOrder[Apple] = singleunit.LimitBidOrder(issuer, Price(10), apple)
 
 // Create a four-heap order book and add some orders...
 val orderBook = FourHeapOrderBook.empty[Google]

--- a/src/main/scala/org/economicsl/auctions/singleunit/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/MarketAskOrder.scala
@@ -23,7 +23,7 @@ import org.economicsl.auctions.{Price, Tradable}
 case class MarketAskOrder[+T <: Tradable](issuer: UUID, tradable: T) extends LimitAskOrder[T] {
 
   /** An issuer of a `MarketAskOrder` is willing to sell at any strictly positive price. */
-  val limit: Price = Price.MinPositiveValue
+  val limit: Price = Price.MinValue
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/pricing/WeightedAveragePricingRule.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/pricing/WeightedAveragePricingRule.scala
@@ -13,6 +13,6 @@ class WeightedAveragePricingRule[T <: Tradable](weight: Double) extends PricingR
 
   private[this] def average(k: Double)(bid: Price, ask: Price): Price = {
     val weightedAverage = k * bid.value.toDouble + (1 - k) * ask.value.toDouble
-    Price(weightedAverage.toLong)  // be mindful of possible overflow!
+    Price(weightedAverage.round)  // be mindful of possible overflow!
   }
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/pricing/WeightedAveragePricingRule.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/pricing/WeightedAveragePricingRule.scala
@@ -5,13 +5,14 @@ import org.economicsl.auctions.{Price, Tradable}
 
 
 class WeightedAveragePricingRule[T <: Tradable](weight: Double) extends PricingRule[T, Price] {
-  require(0.0 <= weight && weight <= 1.0)  // individual rationality requirement!
+  require(0 <= weight && weight <= 1.0)  // individual rationality requirement!
 
   def apply(orderBook: FourHeapOrderBook[T]): Option[Price] = {
     orderBook.askPriceQuote.flatMap(askPrice => orderBook.bidPriceQuote.map(bidPrice=> average(weight)(bidPrice, askPrice)))
   }
 
   private[this] def average(k: Double)(bid: Price, ask: Price): Price = {
-    Price(k * bid.value) + Price((1 - k) * ask.value)
+    val weightedAverage = k * bid.value.toDouble + (1 - k) * ask.value.toDouble
+    Price(weightedAverage.toLong)  // be mindful of possible overflow!
   }
 }


### PR DESCRIPTION
PR that switches from `Double` as the underlying numeric type for both prices and quantities to `Long`.  Still work required to sort out the weighted average pricing rule (which requires multiplying a `Long` by a `Double`).