### PR TITLE
Improving Java interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
           </execution>
         </executions>
       </plugin>
-      <!--<plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>3.0.0</version>
         <configuration>
@@ -53,7 +53,7 @@
             </goals>
           </execution>
         </executions>
-      </plugin>-->
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/src/main/java/org/economicsl/auctions/AppleStock.java
+++ b/src/main/java/org/economicsl/auctions/AppleStock.java
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Robert Bosch GmbH
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.economicsl.auctions;
+
+public class AppleStock extends Security {
+
+    private long tick = 1;
+
+    public AppleStock(long _tick) {
+        tick = _tick;
+    }
+
+    @Override
+    public long tick() {
+        return tick;
+    }
+}

--- a/src/main/java/org/economicsl/auctions/GoogleStock.java
+++ b/src/main/java/org/economicsl/auctions/GoogleStock.java
@@ -1,0 +1,30 @@
+// Copyright (c) 2017 Robert Bosch GmbH
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.economicsl.auctions;
+
+public class GoogleStock extends Security {
+
+    private long tick = 1;
+
+    public GoogleStock(long _tick) {
+        tick = _tick;
+    }
+
+    @Override
+    public long tick() {
+        return tick;
+    }
+}

--- a/src/main/java/org/economicsl/auctions/Sandbox.java
+++ b/src/main/java/org/economicsl/auctions/Sandbox.java
@@ -33,28 +33,28 @@ public class Sandbox {
         UUID issuer = UUID.randomUUID();
         GoogleStock google = new GoogleStock(1);
 
-        org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order1 = org.economicsl.auctions.multiunit.LimitBidOrder$.MODULE$.apply(issuer, 10, 100, google);
+        org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order1 = new org.economicsl.auctions.multiunit.LimitBidOrder<>(issuer, 10, 100, google);
 
         // Create a multi-unit market ask order
-        org.economicsl.auctions.multiunit.MarketAskOrder<GoogleStock> order2 = org.economicsl.auctions.multiunit.MarketAskOrder$.MODULE$.apply(issuer, 100, google);
+        org.economicsl.auctions.multiunit.MarketAskOrder<GoogleStock> order2 = new org.economicsl.auctions.multiunit.MarketAskOrder<>(issuer, 100, google);
 
         // Create some single-unit limit ask orders...
         LimitAskOrder<GoogleStock> order3 = new LimitAskOrder<>(issuer, 5, google);
         LimitAskOrder<GoogleStock> order4 = new LimitAskOrder<>(issuer, 6, google);
 
         // Create a multi-unit limit bid order...
-        org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order5 = org.economicsl.auctions.multiunit.LimitBidOrder$.MODULE$.apply(issuer, 10, 100, google);
+        org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order5 = new org.economicsl.auctions.multiunit.LimitBidOrder<>(issuer, 10, 100, google);
 
         // Create a multi-unit market bid order...
-        org.economicsl.auctions.multiunit.MarketBidOrder<GoogleStock> order7 = org.economicsl.auctions.multiunit.MarketBidOrder$.MODULE$.apply(issuer, 100, google);
+        org.economicsl.auctions.multiunit.MarketBidOrder<GoogleStock> order7 = new org.economicsl.auctions.multiunit.MarketBidOrder<>(issuer, 100, google);
 
         // Create some single-unit limit bid orders...
-        LimitBidOrder<GoogleStock> order8 = LimitBidOrder$.MODULE$.apply(issuer, 10, google);
-        LimitBidOrder<GoogleStock> order9 = LimitBidOrder$.MODULE$.apply(issuer, 6, google);
+        LimitBidOrder<GoogleStock> order8 = new LimitBidOrder<>(issuer, 10, google);
+        LimitBidOrder<GoogleStock> order9 = new LimitBidOrder<>(issuer, 6, google);
 
         // Create an order for some other tradable
         AppleStock apple = new AppleStock(2);
-        LimitBidOrder<AppleStock> order10 = LimitBidOrder$.MODULE$.apply(issuer, 10, apple);
+        LimitBidOrder<AppleStock> order10 = new LimitBidOrder<>(issuer, 10, apple);
 
         // Create a four-heap order book and add some orders...
         FourHeapOrderBook<GoogleStock> orderBook1 = FourHeapOrderBook.empty(

--- a/src/main/java/org/economicsl/auctions/Sandbox.java
+++ b/src/main/java/org/economicsl/auctions/Sandbox.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2017 Robert Bosch GmbH
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.economicsl.auctions;
+
+import org.economicsl.auctions.singleunit.*;
+import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook;
+import org.economicsl.auctions.singleunit.pricing.AskQuotePricingRule;
+import org.economicsl.auctions.singleunit.pricing.BidQuotePricingRule;
+import org.economicsl.auctions.singleunit.pricing.MidPointPricingRule;
+import org.economicsl.auctions.singleunit.pricing.WeightedAveragePricingRule;
+import scala.Option;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class Sandbox {
+
+    public static void main(String[] args) {
+
+        UUID issuer = UUID.randomUUID();
+        GoogleStock google = new GoogleStock(1);
+
+        org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order1 = org.economicsl.auctions.multiunit.LimitBidOrder$.MODULE$.apply(issuer, 10, 100, google);
+
+        // Create a multi-unit market ask order
+        org.economicsl.auctions.multiunit.MarketAskOrder<GoogleStock> order2 = org.economicsl.auctions.multiunit.MarketAskOrder$.MODULE$.apply(issuer, 100, google);
+
+        // Create some single-unit limit ask orders...
+        LimitAskOrder<GoogleStock> order3 = LimitAskOrder$.MODULE$.apply(issuer, 5, google);
+        LimitAskOrder<GoogleStock> order4 = LimitAskOrder$.MODULE$.apply(issuer, 6, google);
+
+        // Create a multi-unit limit bid order...
+        org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order5 = org.economicsl.auctions.multiunit.LimitBidOrder$.MODULE$.apply(issuer, 10, 100, google);
+
+        // Create a multi-unit market bid order...
+        org.economicsl.auctions.multiunit.MarketBidOrder<GoogleStock> order7 = org.economicsl.auctions.multiunit.MarketBidOrder$.MODULE$.apply(issuer, 100, google);
+
+        // Create some single-unit limit bid orders...
+        LimitBidOrder<GoogleStock> order8 = LimitBidOrder$.MODULE$.apply(issuer, 10, google);
+        LimitBidOrder<GoogleStock> order9 = LimitBidOrder$.MODULE$.apply(issuer, 6, google);
+
+        // Create an order for some other tradable
+        AppleStock apple = new AppleStock(2);
+        LimitBidOrder<AppleStock> order10 = LimitBidOrder$.MODULE$.apply(issuer, 10, apple);
+
+        // Create a four-heap order book and add some orders...
+        FourHeapOrderBook<GoogleStock> orderBook1 = FourHeapOrderBook.empty(
+                LimitAskOrder$.MODULE$.ordering(),
+                LimitBidOrder$.MODULE$.ordering());
+
+        FourHeapOrderBook<GoogleStock> orderBook2 = orderBook1.$plus(order3);
+        FourHeapOrderBook<GoogleStock> orderBook3 = orderBook2.$plus(order4);
+        FourHeapOrderBook<GoogleStock> orderBook4 = orderBook3.$plus(order9);
+        FourHeapOrderBook<GoogleStock> orderBook5 = orderBook4.$plus(order8);
+
+        // example of a uniform price auction that would be incentive compatible for the sellers...
+        AskQuotePricingRule<GoogleStock> askQuotePricing = new AskQuotePricingRule<>();
+        Option<Price> price1 = askQuotePricing.apply(orderBook5);
+        if(price1.isDefined()) {
+            System.out.println(price1.get().value());
+        }
+
+        // example of a uniform price auction that would be incentive compatible for the buyers...
+        BidQuotePricingRule<GoogleStock> bidQuotePricing = new BidQuotePricingRule<GoogleStock>();
+        Option<Price> price2 = bidQuotePricing.apply(orderBook5);
+        if(price2.isDefined()) {
+            System.out.println(price2.get().value());
+        }
+
+        // example of a uniform price auction that puts more weight on the bidPriceQuote and yield higher surplus for sellers
+        MidPointPricingRule midPointPricing = new MidPointPricingRule<GoogleStock>();
+        Option<Price> midPrice = midPointPricing.apply(orderBook5);
+        if(midPrice.isDefined()) {
+            System.out.println(midPrice.get().value());
+        }
+
+        // example of a uniform price auction that puts more weight on the bidPriceQuote and yield higher surplus for sellers
+        WeightedAveragePricingRule<GoogleStock> averagePricing = new WeightedAveragePricingRule<GoogleStock>(0.75);
+        Option<Price> averagePrice = averagePricing.apply(orderBook5);
+        if(averagePrice.isDefined()) {
+            System.out.println(averagePrice.get().value());
+        };
+
+        // TODO: take a look at paired orders
+
+        // example usage of a double auction where we don't want to define the pricing rule until later...
+        DoubleAuction.WithClosedOrderBook<GoogleStock> withOrderBook = DoubleAuction$.MODULE$.withClosedOrderBook(orderBook1);
+        DoubleAuction.WithClosedOrderBook<GoogleStock> withOrderBook2 = withOrderBook.insert(order3);
+        DoubleAuction.WithClosedOrderBook<GoogleStock> withOrderBook3 = withOrderBook2.insert(order4);
+        DoubleAuction.WithClosedOrderBook<GoogleStock> withOrderBook4 = withOrderBook3.insert(order9);
+        DoubleAuction.WithClosedOrderBook<GoogleStock> withOrderBook5 = withOrderBook4.insert(order8);
+
+        Clearing<GoogleStock> clearing = new Clearing<GoogleStock>();
+
+        // after inserting orders, now we can define the pricing rule...
+        DoubleAuction<GoogleStock> auction = withOrderBook5.withUniformPricing(midPointPricing);
+        Optional<Clearing<GoogleStock>.ClearResult<GoogleStock>> result = clearing.clear(auction);
+        result.ifPresent(res -> {
+            res.getFills().forEach(fill -> System.out.println(fill));
+        });
+
+        // ...trivial to re-run the same auction with a different pricing rule!
+        DoubleAuction<GoogleStock> auction2 = withOrderBook5.withUniformPricing(askQuotePricing);
+        Optional<Clearing<GoogleStock>.ClearResult<GoogleStock>> result2 = clearing.clear(auction2);
+        result2.ifPresent(res -> {
+            res.getFills().forEach(fill -> System.out.println(fill));
+        });
+
+        // TODO: extend with quotes
+    }
+}

--- a/src/main/java/org/economicsl/auctions/Sandbox.java
+++ b/src/main/java/org/economicsl/auctions/Sandbox.java
@@ -39,8 +39,8 @@ public class Sandbox {
         org.economicsl.auctions.multiunit.MarketAskOrder<GoogleStock> order2 = org.economicsl.auctions.multiunit.MarketAskOrder$.MODULE$.apply(issuer, 100, google);
 
         // Create some single-unit limit ask orders...
-        LimitAskOrder<GoogleStock> order3 = LimitAskOrder$.MODULE$.apply(issuer, 5, google);
-        LimitAskOrder<GoogleStock> order4 = LimitAskOrder$.MODULE$.apply(issuer, 6, google);
+        LimitAskOrder<GoogleStock> order3 = new LimitAskOrder<>(issuer, 5, google);
+        LimitAskOrder<GoogleStock> order4 = new LimitAskOrder<>(issuer, 6, google);
 
         // Create a multi-unit limit bid order...
         org.economicsl.auctions.multiunit.LimitBidOrder<GoogleStock> order5 = org.economicsl.auctions.multiunit.LimitBidOrder$.MODULE$.apply(issuer, 10, 100, google);

--- a/src/main/java/org/economicsl/auctions/Sandbox.java
+++ b/src/main/java/org/economicsl/auctions/Sandbox.java
@@ -61,10 +61,10 @@ public class Sandbox {
                 LimitAskOrder$.MODULE$.ordering(),
                 LimitBidOrder$.MODULE$.ordering());
 
-        FourHeapOrderBook<GoogleStock> orderBook2 = orderBook1.$plus(order3);
-        FourHeapOrderBook<GoogleStock> orderBook3 = orderBook2.$plus(order4);
-        FourHeapOrderBook<GoogleStock> orderBook4 = orderBook3.$plus(order9);
-        FourHeapOrderBook<GoogleStock> orderBook5 = orderBook4.$plus(order8);
+        FourHeapOrderBook<GoogleStock> orderBook2 = orderBook1.insert(order3);
+        FourHeapOrderBook<GoogleStock> orderBook3 = orderBook2.insert(order4);
+        FourHeapOrderBook<GoogleStock> orderBook4 = orderBook3.insert(order9);
+        FourHeapOrderBook<GoogleStock> orderBook5 = orderBook4.insert(order8);
 
         // example of a uniform price auction that would be incentive compatible for the sellers...
         AskQuotePricingRule<GoogleStock> askQuotePricing = new AskQuotePricingRule<>();
@@ -81,7 +81,7 @@ public class Sandbox {
         }
 
         // example of a uniform price auction that puts more weight on the bidPriceQuote and yield higher surplus for sellers
-        MidPointPricingRule midPointPricing = new MidPointPricingRule<GoogleStock>();
+        MidPointPricingRule<GoogleStock> midPointPricing = new MidPointPricingRule<GoogleStock>();
         Option<Price> midPrice = midPointPricing.apply(orderBook5);
         if(midPrice.isDefined()) {
             System.out.println(midPrice.get().value());

--- a/src/main/java/org/economicsl/auctions/Security.java
+++ b/src/main/java/org/economicsl/auctions/Security.java
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Robert Bosch GmbH
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.economicsl.auctions;
+
+public abstract class Security implements Tradable {}

--- a/src/main/java/org/economicsl/auctions/singleunit/Clearing.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/Clearing.java
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Robert Bosch GmbH
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.economicsl.auctions.singleunit;
+
+import org.economicsl.auctions.Tradable;
+import org.economicsl.auctions.singleunit.DoubleAuction;
+import org.economicsl.auctions.singleunit.Fill;
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+import scala.collection.immutable.Stream;
+
+import java.util.List;
+import java.util.Optional;
+
+public class Clearing<T extends Tradable> {
+
+    public class ClearResult<T extends Tradable> {
+        private DoubleAuction<T> auction;
+        private List<Fill<T>> fills;
+
+        public ClearResult(List<Fill<T>> _fills, DoubleAuction<T> _auction) {
+            auction = _auction;
+            fills = _fills;
+        }
+
+        public DoubleAuction<T> getAuction() {
+            return auction;
+        }
+
+        public List<Fill<T>> getFills() {
+            return fills;
+        }
+    }
+
+    public Optional<ClearResult<T>> clear(DoubleAuction<T> auction) {
+        Tuple2<Option<Stream<Fill<T>>>, DoubleAuction<T>> clear = auction.clear();
+        Option<Stream<Fill<T>>> streamOption = clear._1();
+        if(streamOption.isDefined()) {
+            List<Fill<T>> fills = JavaConverters.seqAsJavaListConverter(clear._1().get()).asJava();
+            return Optional.of(new ClearResult<T>(fills, clear._2()));
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/economicsl/auctions/singleunit/Clearing.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/Clearing.java
@@ -16,8 +16,6 @@
 package org.economicsl.auctions.singleunit;
 
 import org.economicsl.auctions.Tradable;
-import org.economicsl.auctions.singleunit.DoubleAuction;
-import org.economicsl.auctions.singleunit.Fill;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.JavaConverters;

--- a/src/main/java/org/economicsl/auctions/singleunit/JDoubleAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JDoubleAuction.java
@@ -17,14 +17,11 @@ package org.economicsl.auctions.singleunit;
 
 import org.economicsl.auctions.Price;
 import org.economicsl.auctions.Tradable;
-import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook;
 import org.economicsl.auctions.singleunit.pricing.PricingRule;
-import org.economicsl.auctions.singleunit.quotes.PriceQuotePolicy;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.Stream;
-import scala.math.Ordering;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/org/economicsl/auctions/singleunit/JDoubleAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JDoubleAuction.java
@@ -17,7 +17,9 @@ package org.economicsl.auctions.singleunit;
 
 import org.economicsl.auctions.Price;
 import org.economicsl.auctions.Tradable;
+import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook;
 import org.economicsl.auctions.singleunit.pricing.PricingRule;
+import org.economicsl.auctions.singleunit.quotes.PriceQuotePolicy;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.JavaConverters;
@@ -30,7 +32,6 @@ import java.util.Optional;
 class JDoubleAuction<T extends Tradable> {
 
     private DoubleAuction<T> auction = null;
-
 
     public class ClearResult<T extends Tradable> {
         private JDoubleAuction<T> auction;
@@ -88,7 +89,52 @@ class JDoubleAuction<T extends Tradable> {
         return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withUniformPricing(p));
     }
 
+    /*public static <T extends Tradable> JDoubleAuction<T> withUniformPricing(FourHeapOrderBook<T> o, PricingRule<T, Price> p) {
+        return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withUniformPricing(o,p));
+    }
+
+    public static <T extends Tradable> JDoubleAuction<T> withUniformPricing(FourHeapOrderBook<T> o, PricingRule<T, Price> p, PriceQuotePolicy<T> q) {
+        return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withUniformPricing(o,p,q));
+    }*/
+
     public static <T extends Tradable> JDoubleAuction<T> withDiscriminatoryPricing(PricingRule<T, Price> p) {
         return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withDiscriminatoryPricing(p));
     }
+
+    /*public static <T extends Tradable> JDoubleAuction<T> withDiscriminatoryPricing(FourHeapOrderBook<T> o, PricingRule<T, Price> p) {
+        return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withDiscriminatoryPricing(o,p));
+    }
+
+    public static <T extends Tradable> JDoubleAuction<T> withDiscriminatoryPricing(FourHeapOrderBook<T> o, PricingRule<T, Price> p, PriceQuotePolicy<T> q) {
+        return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withDiscriminatoryPricing(o,p,q));
+    }
+
+    public static <T extends Tradable> JDoubleAuction<T> withClosedOrderBook(LimitAskOrder<T> r) {
+        return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withClosedOrderBook(r));
+    }
+
+    public static <T extends Tradable> JDoubleAuction<T> withOpenOrderBook(LimitAskOrder<T> r) {
+        return new JDoubleAuction<T>(DoubleAuction$.MODULE$.withOpenOrderBook(r));
+    }*/
+
+    /*private class JUniformPriceImpl<T extends Tradable> extends JDoubleAuction<T> {
+
+        DoubleAuction$.MODULE$.UniformPricing<T> auction = null;
+
+        public JUniformPriceImpl(DoubleAuction$.MODULE$.UniformPriceImpl<T> _auction) {
+            auction = _auction;
+        }
+
+    }
+
+    private class JDiscriminatoryPriceImpl<T extends Tradable> extends JDoubleAuction<T> {
+
+        DoubleAuction$class.
+        DoubleAuction$.MODULE$.DiscriminatoryPricing<T> auction = null;
+
+        public JDiscriminatoryPriceImpl(DoubleAuction$.MODULE$.DiscriminatoryPricing<T> _auction) {
+            auction = _auction;
+        }
+
+    }*/
 }

--- a/src/main/java/org/economicsl/auctions/singleunit/OrderBookTest.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/OrderBookTest.java
@@ -36,8 +36,8 @@ public class OrderBookTest {
         LimitBidOrder<Service> bid1 = LimitBidOrder$.MODULE$.apply(UUID.randomUUID(), 5, service);
         LimitAskOrder<Service> ask1 = LimitAskOrder$.MODULE$.apply(UUID.randomUUID(), 5, service);
 
-        orderbook = orderbook.$plus(bid1);
-        orderbook = orderbook.$plus(ask1);
+        orderbook = orderbook.insert(bid1);
+        orderbook = orderbook.insert(ask1);
 
         Tuple2<Stream<Tuple2<LimitAskOrder<Service>, LimitBidOrder<Service>>>, FourHeapOrderBook<Service>> tuple = orderbook.takeAllMatched();
         List<Tuple2<LimitAskOrder<Service>, LimitBidOrder<Service>>> matchedOrders = JavaConverters.seqAsJavaList(tuple._1());

--- a/src/main/scala/org/economicsl/auctions/multiunit/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/LimitAskOrder.scala
@@ -20,24 +20,22 @@ import java.util.UUID
 import org.economicsl.auctions.{AskOrder, Price, Quantity, Tradable}
 
 
-/** Base trait for a limit order to sell some `Tradable`. */
-trait LimitAskOrder[+T <: Tradable] extends AskOrder[T] with SinglePricePoint[T]
+/** An order to sell multiple units of a tradable at a per-unit price greater than or equal to the limit price. */
+class LimitAskOrder[+T <: Tradable](val issuer: UUID, val limit: Price, val quantity: Quantity, val tradable: T)
+  extends AskOrder[T] with SinglePricePoint[T]
 
 
 /** Companion object for `LimitAskOrder`.
   *
-  * Provides default ordering as well as constructor for default implementation of `LimitAskOrder` trait.
+  * Provides default ordering for the multi-unit `LimitAskOrder` type.
   */
 object LimitAskOrder {
 
   implicit def ordering[O <: LimitAskOrder[_ <: Tradable]]: Ordering[O] = SinglePricePoint.ordering[O]
 
   def apply[T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T): LimitAskOrder[T] = {
-    SinglePricePointImpl(issuer, limit, quantity, tradable)
+    new LimitAskOrder[T](issuer, limit, quantity, tradable)
   }
-
-  private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T)
-    extends LimitAskOrder[T]
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/multiunit/LimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/LimitBidOrder.scala
@@ -19,8 +19,10 @@ import java.util.UUID
 
 import org.economicsl.auctions.{BidOrder, Price, Quantity, Tradable}
 
-/** Base trait for a limit order to buy some `Tradable`. */
-trait LimitBidOrder[+T <: Tradable] extends BidOrder[T] with SinglePricePoint[T]
+
+/** An order to buy multiple units of a tradable at a per-unit price less than or equal to the limit price. */
+class LimitBidOrder[+T <: Tradable](val issuer: UUID, val limit: Price, val quantity: Quantity, val tradable: T)
+  extends BidOrder[T] with SinglePricePoint[T]
 
 
 /** Companion object for `LimitBidOrder`.
@@ -32,11 +34,8 @@ object LimitBidOrder {
   implicit def ordering[O <: LimitBidOrder[_ <: Tradable]]: Ordering[O] = SinglePricePoint.ordering[O].reverse
 
   def apply[T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T): LimitBidOrder[T] = {
-    SinglePricePointImpl(issuer, limit, quantity, tradable)
+    new LimitBidOrder[T](issuer, limit, quantity, tradable)
   }
-
-  private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, limit: Price, quantity: Quantity, tradable: T)
-    extends LimitBidOrder[T]
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/multiunit/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/MarketAskOrder.scala
@@ -17,29 +17,23 @@ package org.economicsl.auctions.multiunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.{Price, Quantity, Tradable}
+import org.economicsl.auctions.{AskOrder, Price, Quantity, Tradable}
 
 
-/** Base trait for a market order to sell some `Tradable`. */
-trait MarketAskOrder[+T <: Tradable] extends LimitAskOrder[T] {
+/** An order to sell a multiple units of a tradable at any positive price. */
+class MarketAskOrder[+T <: Tradable](val issuer: UUID, val quantity: Quantity, val tradable: T)
+  extends AskOrder[T] with SinglePricePoint[T] {
 
-  /** An issuer of a `MarketAskOrder` is willing to sell at any strictly positive price. */
   val limit: Price = Price.MinValue
 
 }
 
-/** Companion object for `MarketAskOrder`.
-  *
-  * Provides constructor for default implementation of `MarketAskOrder` trait.
-  */
+
 object MarketAskOrder {
 
   def apply[T <: Tradable](issuer: UUID, quantity: Quantity, tradable: T): MarketAskOrder[T] = {
-    SinglePricePointImpl(issuer, quantity, tradable)
+    new MarketAskOrder[T](issuer, quantity, tradable)
   }
-
-  private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, quantity: Quantity, tradable: T)
-    extends MarketAskOrder[T]
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/multiunit/MarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/MarketBidOrder.scala
@@ -17,28 +17,22 @@ package org.economicsl.auctions.multiunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.{Price, Quantity, Tradable}
+import org.economicsl.auctions.{BidOrder, Price, Quantity, Tradable}
 
 
-/** Base trait for a market order to buy a particular `Tradable`. */
-trait MarketBidOrder[+T <: Tradable] extends LimitBidOrder[T] {
+/** An order to buy multiple units of a tradable at any positive price. */
+class MarketBidOrder[+T <: Tradable](val issuer: UUID, val quantity: Quantity, val tradable: T)
+  extends BidOrder[T] with SinglePricePoint[T] {
 
-  /** An issuer of a `MarketBidOrder` is willing to pay any finite price. */
   val limit: Price = Price.MaxValue
 
 }
 
-/** Companion object for `MarketBidOrder`.
-  *
-  * Provides constructor for default implementation of `MarketBidOrder` trait.
-  */
+
 object MarketBidOrder {
 
   def apply[T <: Tradable](issuer: UUID, quantity: Quantity, tradable: T): MarketBidOrder[T] = {
-    SinglePricePointImpl(issuer, quantity, tradable)
+    new MarketBidOrder[T](issuer, quantity, tradable)
   }
-
-  private[this] case class SinglePricePointImpl[+T <: Tradable](issuer: UUID, quantity: Quantity, tradable: T)
-    extends MarketBidOrder[T]
 
 }

--- a/src/main/scala/org/economicsl/auctions/multiunit/SinglePricePoint.scala
+++ b/src/main/scala/org/economicsl/auctions/multiunit/SinglePricePoint.scala
@@ -36,7 +36,7 @@ trait SinglePricePoint[+T <: Tradable] extends PriceQuantitySchedule[T] {
   val schedule: immutable.Map[Price, Quantity] = immutable.Map(limit -> quantity)
 
   /** The total value of the order */
-  val value: Currency = limit.value * quantity.value
+  val value: Currency = limit.value * quantity.value // todo sort out units!
 
   require(limit.value % tradable.tick == 0, "Limit price must be a multiple of the tick size!")
 

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -5,7 +5,7 @@ import org.economicsl.auctions.quotes.{AskPriceQuoteRequest, BidPriceQuoteReques
 import org.economicsl.auctions.singleunit.DoubleAuction
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing._
-import org.economicsl.auctions.singleunit.quotes.BasicQuotePolicy
+import org.economicsl.auctions.singleunit.quotes.PriceQuotePolicy
 
 
 /** Example `Tradable` object. */
@@ -93,23 +93,23 @@ val (result2, _) = auction2.clear
 result2.map(fills => fills.map(fill => fill.price).toList)
 
 // example usage of a double auction with discriminatory pricing...
-val basicQuotePolicy = new BasicQuotePolicy[GoogleStock]
+val basicQuotePolicy = new PriceQuotePolicy[GoogleStock]
 val withQuotePolicy = DoubleAuction.withOpenOrderBook[GoogleStock]
                                    .withQuotePolicy(basicQuotePolicy)
 val withQuotePolicy2 = withQuotePolicy.insert(order3)
 val withQuotePolicy3 = withQuotePolicy2.insert(order4)
 
 // suppose that a auction participant asked for aks and/or bid quotes...
-val askQuote = withQuotePolicy3.receive(AskPriceQuoteRequest)
-val bidQuote = withQuotePolicy3.receive(BidPriceQuoteRequest)
+val askQuote = withQuotePolicy3.receive(new AskPriceQuoteRequest)
+val bidQuote = withQuotePolicy3.receive(new BidPriceQuoteRequest)
 
 val withQuotePolicy4 = withQuotePolicy3.insert(order9)
 
 // suppose that another auction participant asked for a spread quote...
-val spreadQuote = withQuotePolicy4.receive(SpreadQuoteRequest)
+val spreadQuote = withQuotePolicy4.receive(new SpreadQuoteRequest)
 
 val withQuotePolicy5 = withQuotePolicy4.insert(order8)
-val bidQuote2 = withQuotePolicy5.receive(BidPriceQuoteRequest)
+val bidQuote2 = withQuotePolicy5.receive(new BidPriceQuoteRequest)
 
 // clear
 val auction3 = withQuotePolicy5.withDiscriminatoryPricing(bidQuotePricing)

--- a/src/main/scala/org/economicsl/auctions/sandbox.sc
+++ b/src/main/scala/org/economicsl/auctions/sandbox.sc
@@ -1,11 +1,9 @@
 import java.util.UUID
 
 import org.economicsl.auctions._
-import org.economicsl.auctions.quotes.{AskPriceQuoteRequest, BidPriceQuoteRequest, SpreadQuoteRequest}
 import org.economicsl.auctions.singleunit.DoubleAuction
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing._
-import org.economicsl.auctions.singleunit.quotes.BasicQuotePolicy
 
 
 /** Example `Tradable` object. */

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -36,7 +36,7 @@ object Auction {
     */
   def apply[T <: Tradable](reservation: LimitAskOrder[T], rule: PricingRule[T, Price]): Auction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new ClosedOrderBookImpl[T](orderBook + reservation, rule)
+    new ClosedOrderBookImpl[T](orderBook insert reservation, rule)
   }
 
   /** Create an `Auction` with a particular reservation price, pricing rule, and quoting policy.
@@ -48,7 +48,7 @@ object Auction {
     */
   def apply[T <: Tradable](reservation: LimitAskOrder[T], rule: PricingRule[T, Price], policy: PriceQuotePolicy[T]): Auction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new OpenOrderBookImpl[T](orderBook + reservation, rule, policy)
+    new OpenOrderBookImpl[T](orderBook insert reservation, rule, policy)
   }
 
   /** Create a first-price, sealed-bid `Auction`.
@@ -59,7 +59,7 @@ object Auction {
     */
   def firstPriceSealedBid[T <: Tradable](reservation: LimitAskOrder[T]): Auction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new ClosedOrderBookImpl[T](orderBook + reservation, new AskQuotePricingRule)
+    new ClosedOrderBookImpl[T](orderBook insert reservation, new AskQuotePricingRule)
   }
 
   /** Create a second-price, sealed-bid or Vickrey `Auction`.
@@ -70,7 +70,7 @@ object Auction {
     */
   def secondPriceSealedBid[T <: Tradable](reservation: LimitAskOrder[T]): Auction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new ClosedOrderBookImpl[T](orderBook + reservation, new BidQuotePricingRule)
+    new ClosedOrderBookImpl[T](orderBook insert reservation, new BidQuotePricingRule)
   }
 
   /** Create `WithClosedOrderBook` that encapsulates an order book containing a particular reservation price.
@@ -81,7 +81,7 @@ object Auction {
     */
   def withClosedOrderBook[T <: Tradable](reservation: LimitAskOrder[T]): WithClosedOrderBook[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithClosedOrderBook[T](orderBook + reservation)
+    new WithClosedOrderBook[T](orderBook insert reservation)
   }
 
   /** Create an `WithOrderBook` that encapsulates an order book containing a particular reservation price.
@@ -92,7 +92,7 @@ object Auction {
     */
   def withOpenOrderBook[T <: Tradable](reservation: LimitAskOrder[T]): WithOpenOrderBook[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithOpenOrderBook[T](orderBook + reservation)
+    new WithOpenOrderBook[T](orderBook insert reservation)
   }
 
 
@@ -108,11 +108,11 @@ object Auction {
   final class WithClosedOrderBook[T <: Tradable] (orderBook: FourHeapOrderBook[T]) extends WithOrderBook[T](orderBook) {
 
     def insert(order: LimitBidOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook[T](orderBook + order)
+      new WithClosedOrderBook[T](orderBook insert order)
     }
 
     def remove(order: LimitBidOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook[T](orderBook - order)
+      new WithClosedOrderBook[T](orderBook remove order)
     }
 
     def withPricingRule(rule: PricingRule[T, Price]): Auction[T] = {
@@ -125,11 +125,11 @@ object Auction {
   final class WithOpenOrderBook[T <: Tradable](orderBook: FourHeapOrderBook[T]) extends WithOrderBook[T](orderBook) {
 
     def insert(order: LimitBidOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook[T](orderBook + order)
+      new WithOpenOrderBook[T](orderBook insert order)
     }
 
     def remove(order: LimitBidOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook[T](orderBook - order)
+      new WithOpenOrderBook[T](orderBook remove order)
     }
 
     def withQuotePolicy(policy: PriceQuotePolicy[T]): WithQuotePolicy[T] = {
@@ -147,11 +147,11 @@ object Auction {
     }
 
     def insert(order: LimitBidOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy[T](orderBook + order, policy)
+      new WithQuotePolicy[T](orderBook insert order, policy)
     }
 
     def remove(order: LimitBidOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy[T](orderBook - order, policy)
+      new WithQuotePolicy[T](orderBook remove order, policy)
     }
 
     def withPricingRule(rule: PricingRule[T, Price]): Auction[T] = {
@@ -165,11 +165,11 @@ object Auction {
     extends Auction[T] {
 
     def insert(order: LimitBidOrder[T]): Auction[T] = {
-      new ClosedOrderBookImpl(orderBook + order, pricingRule)
+      new ClosedOrderBookImpl(orderBook insert order, pricingRule)
     }
 
     def remove(order: LimitBidOrder[T]): Auction[T] = {
-      new ClosedOrderBookImpl(orderBook - order, pricingRule)
+      new ClosedOrderBookImpl(orderBook remove order, pricingRule)
     }
 
     def clear: (Option[Stream[Fill[T]]], Auction[T]) = {
@@ -197,11 +197,11 @@ object Auction {
     }
 
     def insert(order: LimitBidOrder[T]): Auction[T] = {
-      new OpenOrderBookImpl(orderBook + order, pricingRule, policy)
+      new OpenOrderBookImpl(orderBook insert order, pricingRule, policy)
     }
 
     def remove(order: LimitBidOrder[T]): Auction[T] = {
-      new OpenOrderBookImpl(orderBook - order, pricingRule, policy)
+      new OpenOrderBookImpl(orderBook remove order, pricingRule, policy)
     }
 
     def clear: (Option[Stream[Fill[T]]], Auction[T]) = {

--- a/src/main/scala/org/economicsl/auctions/singleunit/DoubleAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/DoubleAuction.scala
@@ -70,12 +70,12 @@ object DoubleAuction {
 
   def withClosedOrderBook[T <: Tradable](reservation: LimitAskOrder[T]): WithClosedOrderBook[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithClosedOrderBook[T](orderBook + reservation)
+    new WithClosedOrderBook[T](orderBook insert reservation)
   }
 
   def withOpenOrderBook[T <: Tradable](reservation: LimitAskOrder[T]): WithOpenOrderBook[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithOpenOrderBook[T](orderBook + reservation)
+    new WithOpenOrderBook[T](orderBook insert reservation)
   }
 
 
@@ -95,19 +95,19 @@ object DoubleAuction {
   final class WithClosedOrderBook[T <: Tradable](orderBook: FourHeapOrderBook[T]) extends WithOrderBook[T](orderBook) {
 
     def insert(order: LimitAskOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook(orderBook + order)
+      new WithClosedOrderBook(orderBook insert order)
     }
 
     def insert(order: LimitBidOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook(orderBook + order)
+      new WithClosedOrderBook(orderBook insert order)
     }
 
     def remove(order: LimitAskOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook(orderBook - order)
+      new WithClosedOrderBook(orderBook remove order)
     }
 
     def remove(order: LimitBidOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook(orderBook - order)
+      new WithClosedOrderBook(orderBook remove order)
     }
 
     def withDiscriminatoryPricing(rule: PricingRule[T, Price]): DoubleAuction[T] = {
@@ -128,19 +128,19 @@ object DoubleAuction {
   final class WithOpenOrderBook[T <: Tradable] (orderBook: FourHeapOrderBook[T]) extends WithOrderBook[T](orderBook) {
 
     def insert(order: LimitAskOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook(orderBook + order)
+      new WithOpenOrderBook(orderBook insert order)
     }
 
     def insert(order: LimitBidOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook(orderBook + order)
+      new WithOpenOrderBook(orderBook insert order)
     }
 
     def remove(order: LimitAskOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook(orderBook - order)
+      new WithOpenOrderBook(orderBook remove order)
     }
 
     def remove(order: LimitBidOrder[T]):WithOpenOrderBook[T] = {
-      new WithOpenOrderBook(orderBook - order)
+      new WithOpenOrderBook(orderBook remove order)
     }
 
     def withQuotePolicy(policy: PriceQuotePolicy[T]): WithQuotePolicy[T] = {
@@ -157,19 +157,19 @@ object DoubleAuction {
     }
 
     def insert(order: LimitAskOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy(orderBook + order, policy)
+      new WithQuotePolicy(orderBook insert order, policy)
     }
 
     def insert(order: LimitBidOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy(orderBook + order, policy)
+      new WithQuotePolicy(orderBook insert order, policy)
     }
 
     def remove(order: LimitAskOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy(orderBook - order, policy)
+      new WithQuotePolicy(orderBook remove order, policy)
     }
 
     def remove(order: LimitBidOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy(orderBook - order, policy)
+      new WithQuotePolicy(orderBook remove order, policy)
     }
 
     def withDiscriminatoryPricing(pricingRule: PricingRule[T, Price]): DoubleAuction[T] = {
@@ -226,19 +226,19 @@ object DoubleAuction {
     extends DoubleAuction[T] with UniformPricing[T] {
 
     def insert(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl(orderBook + order, pricingRule)
+      new UniformPriceImpl(orderBook insert order, pricingRule)
     }
 
     def insert(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl(orderBook + order, pricingRule)
+      new UniformPriceImpl(orderBook insert order, pricingRule)
     }
 
     def remove(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl(orderBook - order, pricingRule)
+      new UniformPriceImpl(orderBook remove order, pricingRule)
     }
 
     def remove(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl(orderBook - order, pricingRule)
+      new UniformPriceImpl(orderBook remove order, pricingRule)
     }
 
     protected def self(): DoubleAuction[T] = {
@@ -256,19 +256,19 @@ object DoubleAuction {
     extends DoubleAuction[T] with UniformPricing[T] {
 
     def insert(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl2(orderBook + order, pricingRule, policy)
+      new UniformPriceImpl2(orderBook insert order, pricingRule, policy)
     }
 
     def insert(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl2(orderBook + order, pricingRule, policy)
+      new UniformPriceImpl2(orderBook insert order, pricingRule, policy)
     }
 
     def remove(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl2(orderBook - order, pricingRule, policy)
+      new UniformPriceImpl2(orderBook remove order, pricingRule, policy)
     }
 
     def remove(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new UniformPriceImpl2(orderBook - order, pricingRule, policy)
+      new UniformPriceImpl2(orderBook remove order, pricingRule, policy)
     }
 
     protected def self(): DoubleAuction[T] = {
@@ -288,19 +288,19 @@ object DoubleAuction {
     extends DoubleAuction[T] with DiscriminatoryPricing[T] {
 
     def insert(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl(orderBook + order, pricingRule)
+      new DiscriminatoryPriceImpl(orderBook insert order, pricingRule)
     }
 
     def insert(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl(orderBook + order, pricingRule)
+      new DiscriminatoryPriceImpl(orderBook insert order, pricingRule)
     }
 
     def remove(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl(orderBook - order, pricingRule)
+      new DiscriminatoryPriceImpl(orderBook remove order, pricingRule)
     }
 
     def remove(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl(orderBook - order, pricingRule)
+      new DiscriminatoryPriceImpl(orderBook remove order, pricingRule)
     }
 
     protected def self(): DoubleAuction[T] = {
@@ -322,19 +322,19 @@ object DoubleAuction {
     }
 
     def insert(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl2(orderBook + order, pricingRule, policy)
+      new DiscriminatoryPriceImpl2(orderBook insert order, pricingRule, policy)
     }
 
     def insert(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl2(orderBook + order, pricingRule, policy)
+      new DiscriminatoryPriceImpl2(orderBook insert order, pricingRule, policy)
     }
 
     def remove(order: LimitAskOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl2(orderBook - order, pricingRule, policy)
+      new DiscriminatoryPriceImpl2(orderBook remove order, pricingRule, policy)
     }
 
     def remove(order: LimitBidOrder[T]): DoubleAuction[T] = {
-      new DiscriminatoryPriceImpl2(orderBook - order, pricingRule, policy)
+      new DiscriminatoryPriceImpl2(orderBook remove order, pricingRule, policy)
     }
 
     protected def self(): DoubleAuction[T] = {

--- a/src/main/scala/org/economicsl/auctions/singleunit/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/LimitAskOrder.scala
@@ -17,22 +17,19 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.{AskOrder, Price, Tradable}
+import org.economicsl.auctions.{Price, Tradable}
 
 
-trait LimitAskOrder[+T <: Tradable] extends AskOrder[T] with SingleUnit[T]
+class LimitAskOrder[+T <: Tradable](val issuer: UUID, val limit: Price, val tradable: T) extends LimitAskOrderLike[T]
 
 
 object LimitAskOrder {
 
   implicit def ordering[O <: LimitAskOrder[_ <: Tradable]]: Ordering[O] = SingleUnit.ordering[O]
 
-
   def apply[T <: Tradable](issuer: UUID, limit: Price, tradable: T): LimitAskOrder[T] = {
-    SingleUnitImpl(issuer, limit, tradable)
+    new LimitAskOrder(issuer, limit, tradable)
   }
-
-  private[this] case class SingleUnitImpl[+T <: Tradable](issuer: UUID, limit: Price, tradable: T) extends LimitAskOrder[T]
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/LimitAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/LimitAskOrder.scala
@@ -20,19 +20,17 @@ import java.util.UUID
 import org.economicsl.auctions.{AskOrder, Price, Tradable}
 
 
-trait LimitAskOrder[+T <: Tradable] extends AskOrder[T] with SingleUnit[T]
+/** An order to sell a single-unit of a tradable at a price greater than or equal to the limit price. */
+class LimitAskOrder[+T <: Tradable](val issuer: UUID, val limit: Price, val tradable: T) extends AskOrder[T] with SingleUnit[T]
 
 
 object LimitAskOrder {
 
   implicit def ordering[O <: LimitAskOrder[_ <: Tradable]]: Ordering[O] = SingleUnit.ordering[O]
 
-
   def apply[T <: Tradable](issuer: UUID, limit: Price, tradable: T): LimitAskOrder[T] = {
-    SingleUnitImpl(issuer, limit, tradable)
+    new LimitAskOrder(issuer, limit, tradable)
   }
-
-  private[this] case class SingleUnitImpl[+T <: Tradable](issuer: UUID, limit: Price, tradable: T) extends LimitAskOrder[T]
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/LimitAskOrderLike.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/LimitAskOrderLike.scala
@@ -1,0 +1,14 @@
+package org.economicsl.auctions.singleunit
+
+
+import org.economicsl.auctions.{AskOrder, Tradable}
+
+
+trait LimitAskOrderLike[+T <: Tradable] extends AskOrder[T] with SingleUnit[T]
+
+
+object LimitAskOrderLike {
+
+  implicit def ordering[O <: LimitAskOrderLike[_ <: Tradable]]: Ordering[O] = SingleUnit.ordering[O]
+
+}

--- a/src/main/scala/org/economicsl/auctions/singleunit/LimitBidOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/LimitBidOrder.scala
@@ -20,7 +20,8 @@ import java.util.UUID
 import org.economicsl.auctions.{BidOrder, Price, Tradable}
 
 
-trait LimitBidOrder[+T <: Tradable] extends BidOrder[T] with SingleUnit[T]
+/** An order to buy a single-unit of a tradable at a price less than or equal to the limit price. */
+class LimitBidOrder[+T <: Tradable](val issuer: UUID, val limit: Price, val tradable: T) extends BidOrder[T] with SingleUnit[T]
 
 
 object LimitBidOrder {
@@ -28,9 +29,7 @@ object LimitBidOrder {
   implicit def ordering[O <: LimitBidOrder[_ <: Tradable]]: Ordering[O] = SingleUnit.ordering[O].reverse
 
   def apply[T <: Tradable](issuer: UUID, limit: Price, tradable: T): LimitBidOrder[T] = {
-    SingleUnitImpl(issuer, limit, tradable)
+    new LimitBidOrder(issuer, limit, tradable)
   }
-
-  private[this] case class SingleUnitImpl[+T <: Tradable](issuer: UUID, limit: Price, tradable: T) extends LimitBidOrder[T]
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/MarketAskOrder.scala
@@ -20,10 +20,14 @@ import java.util.UUID
 import org.economicsl.auctions.{Price, Tradable}
 
 
-case class MarketAskOrder[+T <: Tradable](issuer: UUID, tradable: T) extends LimitAskOrder[T] {
+class MarketAskOrder[+T <: Tradable](issuer: UUID, tradable: T) extends LimitAskOrder[T](issuer, Price.MinValue, tradable)
 
-  /** An issuer of a `MarketAskOrder` is willing to sell at any strictly positive price. */
-  val limit: Price = Price.MinValue
+
+object MarketAskOrder {
+
+  def apply[T <: Tradable](issuer: UUID, tradable: T): MarketAskOrder[T] = {
+    new MarketAskOrder(issuer, tradable)
+  }
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/MarketAskOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/MarketAskOrder.scala
@@ -17,13 +17,21 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.{Price, Tradable}
+import org.economicsl.auctions.{AskOrder, Price, Tradable}
 
 
-case class MarketAskOrder[+T <: Tradable](issuer: UUID, tradable: T) extends LimitAskOrder[T] {
+/** An order to sell a single-unit of a tradable at any positive price. */
+class MarketAskOrder[+T <: Tradable](val issuer: UUID, val tradable: T) extends AskOrder[T] with SingleUnit[T] {
 
-  /** An issuer of a `MarketAskOrder` is willing to sell at any strictly positive price. */
   val limit: Price = Price.MinValue
 
 }
 
+
+object MarketAskOrder {
+
+  def apply[T <: Tradable](issuer: UUID, tradable: T): MarketAskOrder[T] = {
+    new MarketAskOrder[T](issuer, tradable)
+  }
+
+}

--- a/src/main/scala/org/economicsl/auctions/singleunit/MarketBidOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/MarketBidOrder.scala
@@ -17,12 +17,21 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.{Price, Tradable}
+import org.economicsl.auctions.{BidOrder, Price, Tradable}
 
 
-case class MarketBidOrder[+T <: Tradable](issuer: UUID, tradable: T) extends LimitBidOrder[T] {
+/** An order to buy a single-unit of a tradable at any positive price. */
+class MarketBidOrder[+T <: Tradable](val issuer: UUID, val tradable: T) extends BidOrder[T] with SingleUnit[T] {
 
-  /** An issuer of a `MarketBidOrder` is willing to pay any finite price. */
   val limit: Price = Price.MaxValue
+
+}
+
+
+object MarketBidOrder {
+
+  def apply[T <: Tradable](issuer: UUID, tradable: T): MarketBidOrder[T] = {
+    new MarketBidOrder[T](issuer, tradable)
+  }
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/ReverseAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/ReverseAuction.scala
@@ -36,7 +36,7 @@ object ReverseAuction {
     */
   def apply[T <: Tradable](reservation: LimitBidOrder[T], rule: PricingRule[T, Price]): ReverseAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T](LimitAskOrder.ordering.reverse, LimitBidOrder.ordering.reverse)
-    new ClosedOrderBookImpl[T](orderBook + reservation, rule)
+    new ClosedOrderBookImpl[T](orderBook insert reservation, rule)
   }
 
   /** Create a `ReverseAuction` with a particular reservation price, pricing rule, and quoting policy.
@@ -49,17 +49,17 @@ object ReverseAuction {
     */
   def apply[T <: Tradable](reservation: LimitBidOrder[T], rule: PricingRule[T, Price], policy: PriceQuotePolicy[T]): ReverseAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new OpenOrderBookImpl[T](orderBook + reservation, rule, policy)
+    new OpenOrderBookImpl[T](orderBook insert reservation, rule, policy)
   }
 
   def firstPriceSealedBid[T <: Tradable](reservation: LimitBidOrder[T]): ReverseAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T](LimitAskOrder.ordering.reverse, LimitBidOrder.ordering.reverse)
-    new ClosedOrderBookImpl[T](orderBook + reservation, new AskQuotePricingRule)
+    new ClosedOrderBookImpl[T](orderBook insert reservation, new AskQuotePricingRule)
   }
 
   def secondPriceSealedBid[T <: Tradable](reservation: LimitBidOrder[T]): ReverseAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T](LimitAskOrder.ordering.reverse, LimitBidOrder.ordering.reverse)
-    new ClosedOrderBookImpl[T](orderBook + reservation, new BidQuotePricingRule)
+    new ClosedOrderBookImpl[T](orderBook insert reservation, new BidQuotePricingRule)
   }
 
   /** Create `WithClosedOrderBook` that encapsulates an order book containing a particular reservation price.
@@ -70,7 +70,7 @@ object ReverseAuction {
     */
   def withClosedOrderBook[T <: Tradable](reservation: LimitBidOrder[T]): WithClosedOrderBook[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithClosedOrderBook[T](orderBook + reservation)
+    new WithClosedOrderBook[T](orderBook insert reservation)
   }
 
   sealed abstract class WithOrderBook[T <: Tradable](orderBook: FourHeapOrderBook[T]) {
@@ -85,11 +85,11 @@ object ReverseAuction {
   final class WithClosedOrderBook[T <: Tradable] (orderBook: FourHeapOrderBook[T]) extends WithOrderBook[T](orderBook) {
 
     def insert(order: LimitAskOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook[T](orderBook + order)
+      new WithClosedOrderBook[T](orderBook insert order)
     }
 
     def remove(order: LimitAskOrder[T]): WithClosedOrderBook[T] = {
-      new WithClosedOrderBook[T](orderBook - order)
+      new WithClosedOrderBook[T](orderBook remove order)
     }
 
     def withPricingRule(rule: PricingRule[T, Price]): ReverseAuction[T] = {
@@ -102,11 +102,11 @@ object ReverseAuction {
   final class WithOpenOrderBook[T <: Tradable](orderBook: FourHeapOrderBook[T]) extends WithOrderBook[T](orderBook) {
 
     def insert(order: LimitAskOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook[T](orderBook + order)
+      new WithOpenOrderBook[T](orderBook insert order)
     }
 
     def remove(order: LimitAskOrder[T]): WithOpenOrderBook[T] = {
-      new WithOpenOrderBook[T](orderBook - order)
+      new WithOpenOrderBook[T](orderBook remove order)
     }
 
     def withQuotePolicy(policy: PriceQuotePolicy[T]): WithQuotePolicy[T] = {
@@ -124,11 +124,11 @@ object ReverseAuction {
     }
 
     def insert(order: LimitAskOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy[T](orderBook + order, policy)
+      new WithQuotePolicy[T](orderBook insert order, policy)
     }
 
     def remove(order: LimitAskOrder[T]): WithQuotePolicy[T] = {
-      new WithQuotePolicy[T](orderBook - order, policy)
+      new WithQuotePolicy[T](orderBook remove order, policy)
     }
 
     def withPricingRule(rule: PricingRule[T, Price]): ReverseAuction[T] = {
@@ -140,11 +140,11 @@ object ReverseAuction {
     extends ReverseAuction[T] {
 
     def insert(order: LimitAskOrder[T]): ReverseAuction[T] = {
-      new ClosedOrderBookImpl(orderBook + order, pricingRule)
+      new ClosedOrderBookImpl(orderBook insert order, pricingRule)
     }
 
     def remove(order: LimitAskOrder[T]): ReverseAuction[T] = {
-      new ClosedOrderBookImpl(orderBook - order, pricingRule)
+      new ClosedOrderBookImpl(orderBook remove order, pricingRule)
     }
 
     def clear: (Option[Stream[Fill[T]]], ReverseAuction[T]) = {
@@ -172,11 +172,11 @@ object ReverseAuction {
     }
 
     def insert(order: LimitAskOrder[T]): ReverseAuction[T] = {
-      new OpenOrderBookImpl(orderBook + order, pricingRule, policy)
+      new OpenOrderBookImpl(orderBook insert order, pricingRule, policy)
     }
 
     def remove(order: LimitAskOrder[T]): ReverseAuction[T] = {
-      new OpenOrderBookImpl(orderBook - order, pricingRule, policy)
+      new OpenOrderBookImpl(orderBook remove order, pricingRule, policy)
     }
 
     def clear: (Option[Stream[Fill[T]]], ReverseAuction[T]) = {

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
@@ -45,7 +45,7 @@ class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], 
     bidPriceQuote.flatMap(p1 => askPriceQuote.map(p2 => Price(p2.value - p1.value)))
   }
 
-  def - (order: LimitAskOrder[T]): FourHeapOrderBook[T] = {
+  def remove(order: LimitAskOrder[T]): FourHeapOrderBook[T] = {
     if (unMatchedOrders.contains(order)) {
       new FourHeapOrderBook(matchedOrders, unMatchedOrders - order)
     } else {
@@ -54,7 +54,7 @@ class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], 
     }
   }
 
-  def - (order: LimitBidOrder[T]): FourHeapOrderBook[T] = {
+  def remove(order: LimitBidOrder[T]): FourHeapOrderBook[T] = {
     if (unMatchedOrders.contains(order)) {
       new FourHeapOrderBook(matchedOrders, unMatchedOrders - order)
     } else {
@@ -63,7 +63,7 @@ class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], 
     }
   }
 
-  def + (order: LimitAskOrder[T]): FourHeapOrderBook[T] = {
+  def insert(order: LimitAskOrder[T]): FourHeapOrderBook[T] = {
     (matchedOrders.askOrders.headOption, unMatchedOrders.bidOrders.headOption) match {
       case (Some(askOrder), Some(bidOrder)) =>
         if (order.limit <= bidOrder.limit && askOrder.limit <= bidOrder.limit) {
@@ -90,7 +90,7 @@ class FourHeapOrderBook[T <: Tradable] private(matchedOrders: MatchedOrders[T], 
     }
   }
 
-  def + (order: LimitBidOrder[T]): FourHeapOrderBook[T] = {
+  def insert(order: LimitBidOrder[T]): FourHeapOrderBook[T] = {
     (matchedOrders.bidOrders.headOption, unMatchedOrders.askOrders.headOption) match {
       case (Some(bidOrder), Some(askOrder)) =>
         if (order.limit >= askOrder.limit && bidOrder.limit >= askOrder.limit) {

--- a/src/test/scala/org/economicsl/auctions/singleunit/ReverseAuctionSpec.scala
+++ b/src/test/scala/org/economicsl/auctions/singleunit/ReverseAuctionSpec.scala
@@ -28,7 +28,7 @@ class ReverseAuctionSpec extends FlatSpec with Matchers {
 
     val energy = Electricity(tick=10)
     val buyer = UUID.randomUUID()
-    val reservationPrice = MarketBidOrder(buyer, energy)
+    val reservationPrice = LimitBidOrder(buyer, Price(250), energy)
 
     // add a couple of bidders...
     val lowSeller = UUID.randomUUID()


### PR DESCRIPTION
@davidrpugh These are the first steps to improve the Java interface. I first tried to replicate the Scala class structure in Java in order to get the same level of flexibility. I ran into a couple of problems, e.g. related with the `implicit` parameters in `FourHeapOrderBook.empty`. 

Rather than trying to solve all of these problems, I started to re-implement `sandbox.sc` in Java in order to see how easy it would be to use the Scala classes directly (see `src/main/java/org/economicsl/auctions/Sandbox.java`). Surprisingly, that's now rather simple and straightforward. There is still some syntactic clutter (e.g. the '$' characters or the lack of `+`and `-` operators), but overall it looks pretty clear. Also, I added a helper class `Clearing` that encapsulates the conversion of the clearing result into something that's more easily usable in Java.   

I haven't integrated the quoting stuff into the sandbox yet and I haven't tested the direct access from within our demonstrator. I'll do that now. But if it turns out that all of that works, then I'm currently inclined to get rid of the previous Java wrapper (`JDoubleAuction.java`) altogether and use the Scala classes directly. 

What do you think? Is the syntax acceptable from a usability perspective? Some of the stuff could certainly be further simplified, e.g. by adding more helper classes similar to `Clearing.java`. 