### PR TITLE
All contracts should be serializable...

### DIFF
--- a/src/main/scala/org/economicsl/auctions/Contract.scala
+++ b/src/main/scala/org/economicsl/auctions/Contract.scala
@@ -19,7 +19,7 @@ import java.util.UUID
 
 
 /** Type used to indicate that something is a contract. */
-trait Contract {
+trait Contract extends Serializable {
 
   /** Some kind of unique identifier indicating the actor for whom this `Contract` is a liability. */
   def issuer: UUID


### PR DESCRIPTION
...otherwise they can not be passed as messages between JVMs (which is necessary for our economy of things use cases).