### PR TITLE
Now have support for JSON representation of fills.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ lazy val commonSettings = Seq(
   organizationName := "EconomicSL",
   organizationHomepage := Some(url("https://economicsl.github.io/")),
   libraryDependencies ++= Seq(
-    "org.scalactic" %% "scalactic" % "3.0.1"
+    "org.scalactic" %% "scalactic" % "3.0.1",
+    "com.typesafe.play" %% "play-json" % "2.6.0-RC2"
   ),
   resolvers ++= Seq(
     "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",

--- a/src/main/scala/org/economicsl/auctions/Price.scala
+++ b/src/main/scala/org/economicsl/auctions/Price.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package org.economicsl.auctions
 
+import play.api.libs.json.{Json, Writes}
+
 
 /** Value class representing prices.
   *
@@ -39,6 +41,8 @@ object Price {
 
   /** Default ordering for `Price` instances is low to high based on the underlying value. */
   implicit val ordering: Ordering[Price] = PriceOrdering
+
+  implicit val writes: Writes[Price] = Json.writes[Price]
 
   implicit def mkOrderingOps(lhs: Price): PriceOrdering.Ops = PriceOrdering.mkOrderingOps(lhs)
 

--- a/src/main/scala/org/economicsl/auctions/Quantity.scala
+++ b/src/main/scala/org/economicsl/auctions/Quantity.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package org.economicsl.auctions
 
+import play.api.libs.json.{Json, Writes}
+
 
 /** Value class representing quantities.
   *
@@ -40,6 +42,8 @@ case class Quantity(value: Long) extends AnyVal {
   * @since 0.1.0
   */
 object Quantity {
+
+  implicit val writes: Writes[Quantity] = Json.writes[Quantity]
 
   implicit val ordering: Ordering[Quantity] = QuantityOrdering
 

--- a/src/main/scala/org/economicsl/auctions/Tradable.scala
+++ b/src/main/scala/org/economicsl/auctions/Tradable.scala
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package org.economicsl.auctions
 
+import play.api.libs.json.{JsValue, Json, Writes}
+
 
 /** Trait used to indicate that an object can be traded via an auction.
   *
@@ -25,5 +27,16 @@ trait Tradable extends Serializable {
 
   /** Minimum tick size. */
   def tick: Currency
+
+}
+
+
+object Tradable {
+
+  implicit val writes: Writes[Tradable] = new Writes[Tradable] {
+    def writes(o: Tradable): JsValue = Json.obj(
+      "tick" -> o.tick
+    )
+  }
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/Fill.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Fill.scala
@@ -19,6 +19,7 @@ import java.util.UUID
 
 import org.economicsl.auctions.singleunit.orders.{AskOrder, BidOrder}
 import org.economicsl.auctions.{Contract, Price, Tradable}
+import play.api.libs.json.{Json, Writes}
 
 
 /** Class representing a `Fill`.
@@ -37,5 +38,12 @@ case class Fill[T <: Tradable](askOrder: AskOrder[T], bidOrder: BidOrder[T], pri
 
   require(askOrder.limit <= price, s"Fill price of $price, is not greater than seller's limit price of ${askOrder.limit}.")
   require(price <= bidOrder.limit,  s"Fill price of $price, is not less than buyer's limit price of ${bidOrder.limit}.")
+
+}
+
+
+object Fill {
+
+  implicit def writes[T <: Tradable]: Writes[Fill[T]] = Json.writes[Fill[T]]
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/orders/Order.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orders/Order.scala
@@ -16,6 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.singleunit.orders
 
 import org.economicsl.auctions.{Contract, OrderLike, SingleUnit, Tradable}
+import play.api.libs.json.{JsValue, Json, Writes}
 
 
 /** Base trait for all single-unit orders.
@@ -35,6 +36,15 @@ sealed trait Order[+T <: Tradable] extends Contract with OrderLike[T] with Singl
   * @since 0.1.0
   */
 object Order {
+
+  implicit def writes[O <: Order[_ <: Tradable]]: Writes[O] = new Writes[O] {
+    def writes(o: O): JsValue = Json.obj(
+      "issuer" -> o.issuer,
+      "limit" -> o.limit,
+      "quantity" -> o.quantity,
+      "tradable" -> o.tradable
+    )
+  }
 
   /** All `Order` instances are ordered by `limit` from lowest to highest.
     *
@@ -57,6 +67,13 @@ object Order {
 trait AskOrder[+T <: Tradable] extends Order[T]
 
 
+object AskOrder {
+
+  implicit def writes[T <: Tradable]: Writes[AskOrder[T]] = Order.writes[AskOrder[T]]
+
+}
+
+
 /** Base trait for all single-unit orders to buy a particular `Tradable`.
   *
   * @tparam T the type of `Tradable` for which the `BidOrder` is being issued.
@@ -64,3 +81,10 @@ trait AskOrder[+T <: Tradable] extends Order[T]
   * @since 0.1.0
   */
 trait BidOrder[+T <: Tradable] extends Order[T]
+
+
+object BidOrder {
+
+  implicit def writes[T <: Tradable]: Writes[BidOrder[T]] = Order.writes[BidOrder[T]]
+
+}


### PR DESCRIPTION
Related to issue #91 I have gone ahead and implemented logic that allows `Fill` instances to be converted to JSON representation.  This allows client code to more efficiently store simulation output for further processing in Python/R etc.

Would be keen to have feedback on the use of JSON for this task.  Would it be useful to be able to create `Order` instances from JSON inputs? If so I can implement the logic for this as well.

@phelps-sg, @bherd-rb, @ibillett, @EconomicSL/core-devs thoughts?