### PR TITLE
Hot-fix quote type signatures

### DIFF
--- a/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceOpenBidAuction.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceOpenBidAuction.scala
@@ -51,7 +51,7 @@ class FirstPriceOpenBidAuction extends FlatSpec with Matchers with BidOrderGener
   "A First-Price, Open-Bid Auction (FPOBA)" should "be able to process ask price quote requests" in {
 
     val askPriceQuote = withBids.receive(AskPriceQuoteRequest())
-    askPriceQuote should be(Some(AskPriceQuote(bids.max.limit)))
+    askPriceQuote should be(AskPriceQuote(Some(bids.max.limit)))
 
   }
 

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceOpenBidAuction.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceOpenBidAuction.scala
@@ -53,7 +53,7 @@ class SecondPriceOpenBidAuction extends FlatSpec with Matchers with BidOrderGene
   "A Second-Price, Open-Bid Auction (SPOBA)" should "be able to process ask price quote requests" in {
 
     val askPriceQuote = withBids.receive(AskPriceQuoteRequest())
-    askPriceQuote should be(Some(AskPriceQuote(bids.max.limit)))
+    askPriceQuote should be(AskPriceQuote(Some(bids.max.limit)))
 
   }
 

--- a/src/functional/scala/org/economicsl/auctions/singleunit/twosided/ContinuousDoubleAuction.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/twosided/ContinuousDoubleAuction.scala
@@ -75,8 +75,7 @@ object ContinuousDoubleAuction extends App with OrderGenerator {
   }
 
   val spreadQuotes: Stream[SpreadQuote] = {
-    results.map(result => result.residual)
-      .flatMap(auction => auction.receive(SpreadQuoteRequest[GoogleStock]()))
+    results.map(result => result.residual.receive(SpreadQuoteRequest[GoogleStock]()))
   }
 
   // print off the first 10 prices...

--- a/src/main/java/org/economicsl/auctions/singleunit/AbstractOpenBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/AbstractOpenBidAuction.java
@@ -19,11 +19,10 @@ package org.economicsl.auctions.singleunit;
 import org.economicsl.auctions.Tradable;
 import org.economicsl.auctions.quotes.AskPriceQuote;
 import org.economicsl.auctions.quotes.AskPriceQuoteRequest;
-import scala.Option;
 
 
 abstract class AbstractOpenBidAuction<T extends Tradable, A> extends AbstractSealedBidAuction<T, A> {
 
-    public abstract Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request);
+    public abstract AskPriceQuote receive(AskPriceQuoteRequest<T> request);
 
 }

--- a/src/main/java/org/economicsl/auctions/singleunit/JFirstPriceOpenBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JFirstPriceOpenBidAuction.java
@@ -54,7 +54,7 @@ public class JFirstPriceOpenBidAuction<T extends Tradable>
         return new JFirstPriceOpenBidAuction<>(ops.insert(order));
     }
 
-    public Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request) {
+    public AskPriceQuote receive(AskPriceQuoteRequest<T> request) {
         OpenBidAuctionLike.Ops<T, OpenBidAuction<T>> ops = mkAuctionLikeOps(this.auction);
         return ops.receive(request);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/JOpenBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JOpenBidAuction.java
@@ -52,7 +52,7 @@ public class JOpenBidAuction<T extends Tradable> extends AbstractOpenBidAuction<
         return new JOpenBidAuction<>(ops.insert(order));
     }
 
-    public Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request) {
+    public AskPriceQuote receive(AskPriceQuoteRequest<T> request) {
         OpenBidAuctionLike.Ops<T, OpenBidAuction<T>> ops = mkAuctionLikeOps(this.auction);
         return ops.receive(request);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/JSecondPriceOpenBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JSecondPriceOpenBidAuction.java
@@ -54,7 +54,7 @@ public class JSecondPriceOpenBidAuction<T extends Tradable>
         return new JSecondPriceOpenBidAuction<>(ops.insert(order));
     }
 
-    public Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request) {
+    public AskPriceQuote receive(AskPriceQuoteRequest<T> request) {
         OpenBidAuctionLike.Ops<T, OpenBidAuction<T>> ops = OpenBidAuction$.MODULE$.openAuctionLikeOps(this.auction);
         return ops.receive(request);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/reverse/AbstractOpenBidReverseAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/reverse/AbstractOpenBidReverseAuction.java
@@ -19,11 +19,10 @@ package org.economicsl.auctions.singleunit.reverse;
 import org.economicsl.auctions.Tradable;
 import org.economicsl.auctions.quotes.BidPriceQuote;
 import org.economicsl.auctions.quotes.BidPriceQuoteRequest;
-import scala.Option;
 
 
 abstract class AbstractOpenBidReverseAuction<T extends Tradable, A> extends AbstractSealedBidReverseAuction<T, A> {
 
-    public abstract Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request);
+    public abstract BidPriceQuote receive(BidPriceQuoteRequest<T> request);
 
 }

--- a/src/main/java/org/economicsl/auctions/singleunit/reverse/JFirstPriceOpenBidReverseAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/reverse/JFirstPriceOpenBidReverseAuction.java
@@ -57,7 +57,7 @@ public class JFirstPriceOpenBidReverseAuction<T extends Tradable>
         return new JFirstPriceOpenBidReverseAuction<>(ops.insert(order));
     }
 
-    public Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request) {
+    public BidPriceQuote receive(BidPriceQuoteRequest<T> request) {
         OpenBidReverseAuctionLike.Ops<T, OpenBidReverseAuction<T>> ops = mkReverseAuctionLikeOps(this.auction);
         return ops.receive(request);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/reverse/JOpenBidReverseAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/reverse/JOpenBidReverseAuction.java
@@ -57,7 +57,7 @@ public class JOpenBidReverseAuction<T extends Tradable>
         return new JOpenBidReverseAuction<>(ops.insert(order));
     }
 
-    public Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request) {
+    public BidPriceQuote receive(BidPriceQuoteRequest<T> request) {
         OpenBidReverseAuctionLike.Ops<T, OpenBidReverseAuction<T>> ops = mkReverseAuctionLikeOps(this.auction);
         return ops.receive(request);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/reverse/JSecondPriceOpenBidReverseAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/reverse/JSecondPriceOpenBidReverseAuction.java
@@ -58,7 +58,7 @@ public class JSecondPriceOpenBidReverseAuction<T extends Tradable> {
         return new JSecondPriceOpenBidReverseAuction<>(ops.insert(order));
     }
 
-    public Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request) {
+    public BidPriceQuote receive(BidPriceQuoteRequest<T> request) {
         OpenBidReverseAuctionLike.Ops<T, OpenBidReverseAuction<T>> ops = mkReverseAuctionLikeOps(this.auction);
         return ops.receive(request);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/twosided/AbstractOpenBidDoubleAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/twosided/AbstractOpenBidDoubleAuction.java
@@ -18,15 +18,14 @@ package org.economicsl.auctions.singleunit.twosided;
 
 import org.economicsl.auctions.Tradable;
 import org.economicsl.auctions.quotes.*;
-import scala.Option;
 
 
 abstract class AbstractOpenBidDoubleAuction<T extends Tradable, A> extends AbstractSealedBidDoubleAuction<T, A> {
 
-    public abstract Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request);
+    public abstract AskPriceQuote receive(AskPriceQuoteRequest<T> request);
 
-    public abstract Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request);
+    public abstract BidPriceQuote receive(BidPriceQuoteRequest<T> request);
 
-    public abstract Option<SpreadQuote> receive(SpreadQuoteRequest<T> request);
+    public abstract SpreadQuote receive(SpreadQuoteRequest<T> request);
 
 }

--- a/src/main/java/org/economicsl/auctions/singleunit/twosided/JOpenBidDoubleAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/twosided/JOpenBidDoubleAuction.java
@@ -79,17 +79,17 @@ public class JOpenBidDoubleAuction {
             return new DiscriminatoryPricingImpl<>(ops.insert(order));
         }
 
-        public Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request) {
+        public AskPriceQuote receive(AskPriceQuoteRequest<T> request) {
             OpenBidDoubleAuctionLike.Ops<T, OpenBidDoubleAuction.DiscriminatoryPricingImpl<T>> ops = mkDoubleAuctionLikeOps(this.auction);
             return ops.receive(request);
         }
 
-        public Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request) {
+        public BidPriceQuote receive(BidPriceQuoteRequest<T> request) {
             OpenBidDoubleAuctionLike.Ops<T, OpenBidDoubleAuction.DiscriminatoryPricingImpl<T>> ops = mkDoubleAuctionLikeOps(this.auction);
             return ops.receive(request);
         }
 
-        public Option<SpreadQuote> receive(SpreadQuoteRequest<T> request) {
+        public SpreadQuote receive(SpreadQuoteRequest<T> request) {
             OpenBidDoubleAuctionLike.Ops<T, OpenBidDoubleAuction.DiscriminatoryPricingImpl<T>> ops = mkDoubleAuctionLikeOps(this.auction);
             return ops.receive(request);
         }
@@ -178,17 +178,17 @@ public class JOpenBidDoubleAuction {
             return new UniformPricingImpl<>(ops.insert(order));
         }
 
-        public Option<AskPriceQuote> receive(AskPriceQuoteRequest<T> request) {
+        public AskPriceQuote receive(AskPriceQuoteRequest<T> request) {
             OpenBidDoubleAuctionLike.Ops<T, OpenBidDoubleAuction.UniformPricingImpl<T>> ops = mkDoubleAuctionLikeOps(this.auction);
             return ops.receive(request);
         }
 
-        public Option<BidPriceQuote> receive(BidPriceQuoteRequest<T> request) {
+        public BidPriceQuote receive(BidPriceQuoteRequest<T> request) {
             OpenBidDoubleAuctionLike.Ops<T, OpenBidDoubleAuction.UniformPricingImpl<T>> ops = mkDoubleAuctionLikeOps(this.auction);
             return ops.receive(request);
         }
 
-        public Option<SpreadQuote> receive(SpreadQuoteRequest<T> request) {
+        public SpreadQuote receive(SpreadQuoteRequest<T> request) {
             OpenBidDoubleAuctionLike.Ops<T, OpenBidDoubleAuction.UniformPricingImpl<T>> ops = mkDoubleAuctionLikeOps(this.auction);
             return ops.receive(request);
         }

--- a/src/main/scala/org/economicsl/auctions/quotes/Quote.scala
+++ b/src/main/scala/org/economicsl/auctions/quotes/Quote.scala
@@ -33,7 +33,7 @@ sealed trait Quote
   */
 trait PriceQuote extends Quote {
 
-  def quote: Price
+  def quote: Option[Price]
 
 }
 
@@ -44,7 +44,7 @@ trait PriceQuote extends Quote {
   * @author davidrpugh
   * @since 0.1.0
   */
-case class AskPriceQuote(quote: Price) extends PriceQuote
+case class AskPriceQuote(quote: Option[Price]) extends PriceQuote
 
 
 /** Class implementing a bid price quote.
@@ -53,7 +53,7 @@ case class AskPriceQuote(quote: Price) extends PriceQuote
   * @author davidrpugh
   * @since 0.1.0
   */
-case class BidPriceQuote(quote: Price) extends PriceQuote
+case class BidPriceQuote(quote: Option[Price]) extends PriceQuote
 
 
 /** Class implementing a spread quote.
@@ -64,4 +64,4 @@ case class BidPriceQuote(quote: Price) extends PriceQuote
   * @todo a spread is the difference between two prices and as such the unit is not really `Price` but rather should
   *       be `Currency`.
   */
-case class SpreadQuote(quote: Price) extends PriceQuote
+case class SpreadQuote(quote: Option[Price]) extends PriceQuote

--- a/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuction.scala
@@ -54,7 +54,7 @@ object OpenBidAuction {
         new OpenBidAuction[T](a.orderBook.insert(order), a.pricingPolicy)
       }
 
-      def receive(a: OpenBidAuction[T], request: AskPriceQuoteRequest[T]): Option[AskPriceQuote] = {
+      def receive(a: OpenBidAuction[T], request: AskPriceQuoteRequest[T]): AskPriceQuote = {
         askPriceQuotingPolicy(a.orderBook, request)
       }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuctionLike.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuctionLike.scala
@@ -53,7 +53,7 @@ object OpenBidAuctionLike {
       */
     def insert(order: BidOrder[T]): A = ev.insert(a, order)
 
-    def receive(request: AskPriceQuoteRequest[T]): Option[AskPriceQuote] = ev.receive(a, request)
+    def receive(request: AskPriceQuoteRequest[T]): AskPriceQuote = ev.receive(a, request)
 
     /** Create a new instance of type class `A` whose order book contains all previously submitted `BidOrder` instances
       * except the `order`.

--- a/src/main/scala/org/economicsl/auctions/singleunit/quoting/AskPriceQuoting.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/quoting/AskPriceQuoting.scala
@@ -26,6 +26,6 @@ import org.economicsl.auctions.quotes.{AskPriceQuote, AskPriceQuoteRequest}
   */
 trait AskPriceQuoting[T <: Tradable, -A] {
 
-  def receive(a: A, request: AskPriceQuoteRequest[T]): Option[AskPriceQuote]
+  def receive(a: A, request: AskPriceQuoteRequest[T]): AskPriceQuote
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/quoting/BidPriceQuoting.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/quoting/BidPriceQuoting.scala
@@ -26,6 +26,6 @@ import org.economicsl.auctions.quotes.{BidPriceQuote, BidPriceQuoteRequest}
   */
 trait BidPriceQuoting[T <: Tradable, -A] {
 
-  def receive(a: A, request: BidPriceQuoteRequest[T]): Option[BidPriceQuote]
+  def receive(a: A, request: BidPriceQuoteRequest[T]): BidPriceQuote
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/quoting/QuotingPolicy.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/quoting/QuotingPolicy.scala
@@ -25,7 +25,7 @@ import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
   * @author davidrpugh
   * @since 0.1.0
   */
-sealed trait QuotingPolicy[T <: Tradable, -R <: QuoteRequest[T], +Q <: Quote] extends ((FourHeapOrderBook[T], R) => Option[Q])
+sealed trait QuotingPolicy[T <: Tradable, -R <: QuoteRequest[T], +Q <: Quote] extends ((FourHeapOrderBook[T], R) => Q)
 
 
 /**
@@ -35,8 +35,8 @@ sealed trait QuotingPolicy[T <: Tradable, -R <: QuoteRequest[T], +Q <: Quote] ex
   */
 class AskPriceQuotingPolicy[T <: Tradable] extends QuotingPolicy[T, AskPriceQuoteRequest[T], AskPriceQuote] {
 
-  def apply(orderBook: FourHeapOrderBook[T], request: AskPriceQuoteRequest[T]): Option[AskPriceQuote] = {
-    orderBook.askPriceQuote.map(quote => AskPriceQuote(quote))
+  def apply(orderBook: FourHeapOrderBook[T], request: AskPriceQuoteRequest[T]): AskPriceQuote = {
+    AskPriceQuote(orderBook.askPriceQuote)
   }
 
 }
@@ -49,25 +49,8 @@ class AskPriceQuotingPolicy[T <: Tradable] extends QuotingPolicy[T, AskPriceQuot
   */
 class BidPriceQuotingPolicy[T <: Tradable] extends QuotingPolicy[T, BidPriceQuoteRequest[T], BidPriceQuote] {
 
-  def apply(orderBook: FourHeapOrderBook[T], request: BidPriceQuoteRequest[T]): Option[BidPriceQuote] = {
-    orderBook.bidPriceQuote.map(quote => BidPriceQuote(quote))
-  }
-
-}
-
-
-/**
-  *
-  * @author davidrpugh
-  * @since 0.1.0
-  */
-class PriceQuotingPolicy[T <: Tradable] extends QuotingPolicy[T, PriceQuoteRequest[T], PriceQuote] {
-
-  def apply(orderBook: FourHeapOrderBook[T], request: PriceQuoteRequest[T]): Option[PriceQuote] = request match {
-    case _: AskPriceQuoteRequest[T] => orderBook.askPriceQuote.map(quote => AskPriceQuote(quote))
-    case _: BidPriceQuoteRequest[T] => orderBook.bidPriceQuote.map(quote => BidPriceQuote(quote))
-    case _: SpreadQuoteRequest[T] => orderBook.spread.map(quote => SpreadQuote(quote))
-    case _ => None
+  def apply(orderBook: FourHeapOrderBook[T], request: BidPriceQuoteRequest[T]): BidPriceQuote = {
+    BidPriceQuote(orderBook.bidPriceQuote)
   }
 
 }
@@ -80,8 +63,8 @@ class PriceQuotingPolicy[T <: Tradable] extends QuotingPolicy[T, PriceQuoteReque
   */
 class SpreadQuotingPolicy[T <: Tradable] extends QuotingPolicy[T, SpreadQuoteRequest[T], SpreadQuote] {
 
-  def apply(orderBook: FourHeapOrderBook[T], request: SpreadQuoteRequest[T]): Option[SpreadQuote] = {
-    orderBook.spread.map(quote => SpreadQuote(quote))
+  def apply(orderBook: FourHeapOrderBook[T], request: SpreadQuoteRequest[T]): SpreadQuote = {
+    SpreadQuote(orderBook.spread)
   }
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/quoting/SpreadQuoting.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/quoting/SpreadQuoting.scala
@@ -26,6 +26,6 @@ import org.economicsl.auctions.quotes.{SpreadQuote, SpreadQuoteRequest}
   */
 trait SpreadQuoting[T <: Tradable, -A] {
 
-  def receive(a: A, request: SpreadQuoteRequest[T]): Option[SpreadQuote]
+  def receive(a: A, request: SpreadQuoteRequest[T]): SpreadQuote
 
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/reverse/OpenBidReverseAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/reverse/OpenBidReverseAuction.scala
@@ -54,7 +54,7 @@ object OpenBidReverseAuction {
         new OpenBidReverseAuction[T](a.orderBook.insert(order), a.pricingPolicy)
       }
 
-      def receive(a: OpenBidReverseAuction[T], request: BidPriceQuoteRequest[T]): Option[BidPriceQuote] = {
+      def receive(a: OpenBidReverseAuction[T], request: BidPriceQuoteRequest[T]): BidPriceQuote = {
         bidPriceQuotingPolicy(a.orderBook, request)
       }
       

--- a/src/main/scala/org/economicsl/auctions/singleunit/reverse/OpenBidReverseAuctionLike.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/reverse/OpenBidReverseAuctionLike.scala
@@ -56,7 +56,7 @@ object OpenBidReverseAuctionLike {
       */
     def insert(order: AskOrder[T]): A = ev.insert(a, order)
 
-    def receive(request: BidPriceQuoteRequest[T]): Option[BidPriceQuote] = ev.receive(a, request)
+    def receive(request: BidPriceQuoteRequest[T]): BidPriceQuote = ev.receive(a, request)
 
     /** Create a new instance of type class `A` whose order book contains all previously submitted `AskOrder` instances
       * except the `order`.

--- a/src/main/scala/org/economicsl/auctions/singleunit/twosided/OpenBidDoubleAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/twosided/OpenBidDoubleAuction.scala
@@ -99,15 +99,15 @@ object OpenBidDoubleAuction {
           new DiscriminatoryPricingImpl[T](a.orderBook.insert(order), a.pricingPolicy)
         }
 
-        def receive(a: DiscriminatoryPricingImpl[T], request: AskPriceQuoteRequest[T]): Option[AskPriceQuote] = {
+        def receive(a: DiscriminatoryPricingImpl[T], request: AskPriceQuoteRequest[T]): AskPriceQuote = {
           askPriceQuotingPolicy(a.orderBook, request)
         }
 
-        def receive(a: DiscriminatoryPricingImpl[T], request: BidPriceQuoteRequest[T]): Option[BidPriceQuote] = {
+        def receive(a: DiscriminatoryPricingImpl[T], request: BidPriceQuoteRequest[T]): BidPriceQuote = {
           bidPriceQuotingPolicy(a.orderBook, request)
         }
 
-        def receive(a: DiscriminatoryPricingImpl[T], request: SpreadQuoteRequest[T]): Option[SpreadQuote] = {
+        def receive(a: DiscriminatoryPricingImpl[T], request: SpreadQuoteRequest[T]): SpreadQuote = {
           spreadQuotingPolicy(a.orderBook, request)
         }
 
@@ -167,15 +167,15 @@ object OpenBidDoubleAuction {
           new UniformPricingImpl[T](a.orderBook.insert(order), a.pricingPolicy)
         }
 
-        def receive(a: UniformPricingImpl[T], request: AskPriceQuoteRequest[T]): Option[AskPriceQuote] = {
+        def receive(a: UniformPricingImpl[T], request: AskPriceQuoteRequest[T]): AskPriceQuote = {
           askPriceQuotingPolicy(a.orderBook, request)
         }
 
-        def receive(a: UniformPricingImpl[T], request: BidPriceQuoteRequest[T]): Option[BidPriceQuote] = {
+        def receive(a: UniformPricingImpl[T], request: BidPriceQuoteRequest[T]): BidPriceQuote = {
           bidPriceQuotingPolicy(a.orderBook, request)
         }
 
-        def receive(a: UniformPricingImpl[T], request: SpreadQuoteRequest[T]): Option[SpreadQuote] = {
+        def receive(a: UniformPricingImpl[T], request: SpreadQuoteRequest[T]): SpreadQuote = {
           spreadQuotingPolicy(a.orderBook, request)
         }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/twosided/OpenBidDoubleAuctionLike.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/twosided/OpenBidDoubleAuctionLike.scala
@@ -66,11 +66,11 @@ object OpenBidDoubleAuctionLike {
       */
     def insert(order: BidOrder[T]): A = ev.insert(a, order)
 
-    def receive(request: AskPriceQuoteRequest[T]): Option[AskPriceQuote] = ev.receive(a, request)
+    def receive(request: AskPriceQuoteRequest[T]): AskPriceQuote = ev.receive(a, request)
 
-    def receive(request: BidPriceQuoteRequest[T]): Option[BidPriceQuote] = ev.receive(a, request)
+    def receive(request: BidPriceQuoteRequest[T]): BidPriceQuote = ev.receive(a, request)
 
-    def receive(request: SpreadQuoteRequest[T]): Option[SpreadQuote] = ev.receive(a, request)
+    def receive(request: SpreadQuoteRequest[T]): SpreadQuote = ev.receive(a, request)
 
     /** Create a new instance of type class `A` whose order book contains all previously submitted `AskOrder` and
       * `BidOrder` instances except the `order`.


### PR DESCRIPTION
Want to be able to embed auctions inside Akka actors.  Pattern matching on multiple `Option[T]` inside `receive` block of an actor is tricky due to type erasure.  Inverting the type signatures of the various quote types will allow actors to respond to various quote type individually.