### PR TITLE
Made the settlementService field optional.

### DIFF
--- a/src/main/scala/org/economicsl/auctions/actors/AuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/AuctionActor.scala
@@ -18,7 +18,12 @@ trait AuctionActor[T <: Tradable, A <: Auction[T, A]]
 
   var auction: A
 
-  def settlementService: ActorRef
+  /** ActorRef for the settlement service.
+    *
+    * @note in a remote context one might need to create an `AuctionActor` without knowing the location of the
+    *       `SettlementServiceActor`. Use of `Option[ActorRef]` as type allows user to initialize this field to `None`.
+    */
+  def settlementService: Option[ActorRef]
 
   override def receive: Receive = {
     processOrders orElse registerAuctionParticipants

--- a/src/main/scala/org/economicsl/auctions/actors/ContinuousAuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/ContinuousAuctionActor.scala
@@ -35,7 +35,7 @@ object ContinuousAuctionActor {
                                        tradable: T)
                                       : Props = {
     val auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tickSize, tradable)
-    Props(new ContinuousAuctionActorImpl(auction, settlementService))
+    Props(new ContinuousAuctionActorImpl(auction, Some(settlementService)))
   }
 
   def withUniformClearingPolicy[T <: Tradable]
@@ -45,13 +45,13 @@ object ContinuousAuctionActor {
                                 tradable: T)
                                : Props = {
     val auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, tickSize, tradable)
-    Props(new ContinuousAuctionActorImpl(auction, settlementService))
+    Props(new ContinuousAuctionActorImpl(auction, Some(settlementService)))
   }
 
 
   private class ContinuousAuctionActorImpl[T <: Tradable](
     var auction: SealedBidAuction[T],
-    val settlementService: ActorRef)
+    val settlementService: Option[ActorRef])
       extends ContinuousAuctionActor[T, SealedBidAuction[T]]
 
 }

--- a/src/main/scala/org/economicsl/auctions/actors/PeriodicAuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/PeriodicAuctionActor.scala
@@ -39,7 +39,7 @@ object PeriodicAuctionActor {
                                        tradable: T)
                                        : Props = {
     val auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tickSize, tradable)
-    Props(new PeriodicAuctionActorImpl(auction, initialDelay, interval, settlementService))
+    Props(new PeriodicAuctionActorImpl(auction, initialDelay, interval, Some(settlementService)))
   }
 
   def withUniformClearingPolicy[T <: Tradable]
@@ -51,7 +51,7 @@ object PeriodicAuctionActor {
                                 tradable: T)
                                 : Props = {
     val auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, tickSize, tradable)
-    Props(new PeriodicAuctionActorImpl(auction, initialDelay, interval, settlementService))
+    Props(new PeriodicAuctionActorImpl(auction, initialDelay, interval, Some(settlementService)))
   }
 
 
@@ -59,7 +59,7 @@ object PeriodicAuctionActor {
     var auction: SealedBidAuction[T],
     val initialDelay: FiniteDuration,
     val interval: FiniteDuration,
-    val settlementService: ActorRef)
+    val settlementService: Option[ActorRef])
       extends PeriodicAuctionActor[T, SealedBidAuction[T]] {
 
   }


### PR DESCRIPTION
In a remote context one might not know the location and hence the `ActorRef` for the `SettlementActor` when creating an instance of an `AuctionActor`. Making the type of `settlementService` `Option[ActorRef]` allows users to initialize the field to `None`.