### PR TITLE
First draft of the combineWith method for auctions.

### DIFF
--- a/src/functional/scala/org/economicsl/auctions/singleunit/AuctionSimulation.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/AuctionSimulation.scala
@@ -8,17 +8,20 @@ import org.economicsl.core.Tradable
 
 trait AuctionSimulation {
 
-  type InsertResult[T <: Tradable, A <: Auction[T, A]] = (A, Stream[Either[Rejected, Accepted]])
+  type OrderFlow[+T <: Tradable] = Stream[(Token, SingleUnitOrder[T])]
 
-  def insert[T <: Tradable, A <: Auction[T, A]](initial: A)(orders: Stream[(Token, SingleUnitOrder[T])]): (A, Stream[Either[Rejected, Accepted]]) = {
-    orders.aggregate((initial, Stream.empty[Either[Rejected, Accepted]]))({
-      case ((auction, insertResults), order) =>
-        val (updated, insertResult) = auction.insert(order)
-        (updated, insertResult #:: insertResults)
+  type Result[T <: Tradable, A <: Auction[T, A]] = (A, Stream[Either[Rejected, Accepted]])
+
+  def collectOrders[T <: Tradable, A <: Auction[T, A]](auction: A)(orders: OrderFlow[T]): Result[T, A] = {
+    val initialResult: Result[T, A] = (auction, Stream.empty[Either[Rejected, Accepted]])
+    orders.aggregate(initialResult)({
+      case ((currentAuction, results), order) =>
+        val (updatedAuction, result) = currentAuction.insert(order)
+        (updatedAuction, result #:: results)
     }, {
-      case ((auction1, results1), (auction2, results2)) => (auction1.combineWith(auction2), results1.append(results2))
-    }
-    )
+      case ((auction1, results1), (auction2, results2)) =>
+        (auction1.combineWith(auction2), results1.append(results2))
+    })
   }
 
 }

--- a/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceOpenBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceOpenBidAuctionSpec.scala
@@ -58,7 +58,7 @@ class FirstPriceOpenBidAuctionSpec
   val (withReservationAskOrder, _) = firstPriceOpenBidAuction.insert(reservation)
 
   // withBidOrders will include all accepted bids (this is trivially parallel..)
-  val (withBidOrders, _) = insert[ParkingSpace, OpenBidAuction[ParkingSpace]](withReservationAskOrder)(bidOrders)
+  val (withBidOrders, _) = collectOrders[ParkingSpace, OpenBidAuction[ParkingSpace]](withReservationAskOrder)(bidOrders)
   val (clearedAuction, clearResults) = withBidOrders.clear
 
   "A First-Price, Open-Bid Auction (FPOBA)" should "be able to process ask price quote requests" in {

--- a/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceSealedBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceSealedBidAuctionSpec.scala
@@ -17,7 +17,6 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.OrderTracker.{Accepted, Rejected}
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.auctions.singleunit.pricing.AskQuotePricingPolicy
 import org.economicsl.auctions._
@@ -35,6 +34,7 @@ import scala.util.Random
 class FirstPriceSealedBidAuctionSpec
     extends FlatSpec
     with Matchers
+    with AuctionSimulation
     with TokenGenerator {
 
   // seller uses a first-priced, sealed bid auction...
@@ -59,12 +59,7 @@ class FirstPriceSealedBidAuctionSpec
   }
   val (_, highestPricedBidOrder) = bidOrders.maxBy{ case (_, bidOrder) => bidOrder.limit }
 
-  val (withBidOrders, _) = bidOrders.foldLeft((withReservationAskOrder, Stream.empty[Either[Rejected, Accepted]])) {
-    case ((auction, insertResults), bidOrder) =>
-      val (updated, insertResult) = auction.insert(bidOrder)
-      (updated, insertResult #:: insertResults)
-  }
-
+  val (withBidOrders, _) = collectOrders[ParkingSpace, SealedBidAuction[ParkingSpace]](withReservationAskOrder)(bidOrders)
   val (clearedAuction, fills) = withBidOrders.clear
 
   "A first-price, sealed-bid auction (FPSBA)" should "allocate the Tradable to the bidder that submits the bid with the highest price." in {

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceOpenBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceOpenBidAuctionSpec.scala
@@ -17,7 +17,6 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.OrderTracker.{Accepted, Rejected}
 import org.economicsl.auctions._
 import org.economicsl.auctions.quotes.AskPriceQuoteRequest
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
@@ -35,6 +34,7 @@ import scala.util.Random
   */
 class SecondPriceOpenBidAuctionSpec
     extends FlatSpec
+    with AuctionSimulation
     with Matchers {
 
   // seller is willing to sell at any positive price...but wants incentive compatible mechanism for buyers!
@@ -57,11 +57,7 @@ class SecondPriceOpenBidAuctionSpec
   val (_, highestPricedBidOrder) = bidOrders.maxBy{ case (_, order) => order.limit }
 
   // winner should be the bidder that submitted the highest bid
-  val (withBidOrders, insertResults) = bidOrders.foldLeft((withReservationAskOrder, Stream.empty[Either[Rejected, Accepted]])) {
-    case ((auction, results), bidOrder) =>
-      val (updatedAuction, result) = auction.insert(bidOrder)
-      (updatedAuction, result #:: results)
-  }
+  val (withBidOrders, _) = collectOrders[ParkingSpace, OpenBidAuction[ParkingSpace]](withReservationAskOrder)(bidOrders)
   val (clearedAuction, fills): (OpenBidAuction[ParkingSpace], Option[Stream[SpotContract]]) = withBidOrders.clear
 
   "A Second-Price, Open-Bid Auction (SPOBA)" should "be able to process ask price quote requests" in {

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidAuctionSpec.scala
@@ -17,7 +17,6 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.OrderTracker.{Accepted, Rejected}
 import org.economicsl.auctions._
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.auctions.singleunit.pricing.BidQuotePricingPolicy
@@ -35,6 +34,7 @@ import scala.util.Random
 class SecondPriceSealedBidAuctionSpec
     extends FlatSpec
     with Matchers
+    with AuctionSimulation
     with TokenGenerator {
 
   // seller is willing to sell at any positive price...but wants incentive compatible mechanism for buyers!
@@ -56,12 +56,7 @@ class SecondPriceSealedBidAuctionSpec
   val (_, highestPricedBidOrder) = bidOrders.maxBy{ case (_, order) => order.limit }
 
   // winner should be the bidder that submitted the highest bid
-  val (withBidOrders, insertResults) = bidOrders.foldLeft((withReservationAskOrder, Stream.empty[Either[Rejected, Accepted]])) {
-    case ((auction, results), bidOrder) =>
-      val (updatedAuction, result) = auction.insert(bidOrder)
-
-      (updatedAuction, result #:: results)
-  }
+  val (withBidOrders, _) = collectOrders[ParkingSpace, SealedBidAuction[ParkingSpace]](withReservationAskOrder)(bidOrders)
   val (clearedAuction, fills): (SealedBidAuction[ParkingSpace], Option[Stream[SpotContract]]) = withBidOrders.clear
 
   "A Second-Price, Sealed-Bid Auction (SPSBA)" should "allocate the Tradable to the bidder that submitted the bid with the highest price." in {

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidReverseAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidReverseAuctionSpec.scala
@@ -17,7 +17,6 @@ package org.economicsl.auctions.singleunit
 
 import java.util.UUID
 
-import org.economicsl.auctions.OrderTracker.{Accepted, Rejected}
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.auctions.singleunit.pricing.AskQuotePricingPolicy
 import org.economicsl.auctions._
@@ -34,6 +33,7 @@ import scala.util.Random
   */
 class SecondPriceSealedBidReverseAuctionSpec
     extends FlatSpec
+    with AuctionSimulation
     with Matchers {
 
   // reverse auction to procure a service at lowest possible cost...
@@ -55,14 +55,7 @@ class SecondPriceSealedBidReverseAuctionSpec
   val (_, lowestPricedAskOrder): (Token, SingleUnitAskOrder[Service]) = offers.minBy{ case (_, order) => order.limit }
 
   // insert the ask orders into the auction mechanism...can be done in parallel!
-  val (withAskOrders, _): (SealedBidAuction[Service], Stream[Either[Rejected, Accepted]]) = {
-    offers.foldLeft((withReservationBidOrder, Stream.empty[Either[Rejected, Accepted]])) {
-      case ((auction, insertResults), askOrder) =>
-        val (updatedAuction, insertResult) = auction.insert(askOrder)
-        (updatedAuction, insertResult #:: insertResults)
-    }
-  }
-
+  val (withAskOrders, _) = collectOrders[Service, SealedBidAuction[Service]](withReservationBidOrder)(offers)
   val (clearedAuction, fills) = withAskOrders.clear
 
   "A Second-Price, Sealed-Ask Reverse Auction (SPSBRA)" should "purchase the Service from the seller who offers it at the lowest price." in {

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -66,6 +66,14 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
     */
   def clear: (A, Option[Stream[SpotContract]])
 
+  /** Combines and `Auction` mechanism with some other `Auction`.
+  *
+    * @param that
+    * @return
+    * @note this method is necessary in order to parallelize auction simulations.
+    */
+  def combineWith(that: A): A
+
   /** Create a new instance of type class `A` whose order book contains an additional `BidOrder`.
     *
     * @param kv a mapping between a unique (to the auction participant) `Token` and the `BidOrder` that should be

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -72,7 +72,13 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
     * @return
     * @note this method is necessary in order to parallelize auction simulations.
     */
-  def combineWith(that: A): A
+  def combineWith(that: A): A = {
+    require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
+    val combinedOrderBooks = orderBook.combineWith(that.orderBook)
+    val withCombinedOrderBooks = withOrderBook(combinedOrderBooks)
+    val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes! overflow!
+    withCombinedOrderBooks.withTickSize(updatedTickSize)
+  }
 
   /** Create a new instance of type class `A` whose order book contains an additional `BidOrder`.
     *

--- a/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
@@ -74,6 +74,20 @@ object SealedBidAuction {
       extends SealedBidAuction[T]
       with DiscriminatoryClearingPolicy[T, SealedBidAuction[T]] {
 
+    /** Combines this `SealedBidAuction` mechanism with some other `SealedBidAuction`.
+      *
+      * @param that
+      * @return
+      * @note this method is necessary in order to parallelize auction simulations.
+      */
+    def combineWith(that: SealedBidAuction[T]): SealedBidAuction[T] = {
+      require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
+      val combinedOrderBooks = orderBook.combineWith(that.orderBook)
+      val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes!
+      val updatedPricingPolicy: PricingPolicy[T] = ???
+      new WithDiscriminatoryClearingPolicy(combinedOrderBooks, updatedPricingPolicy, updatedTickSize, tradable)
+    }
+
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): SealedBidAuction[T] = {
       new WithDiscriminatoryClearingPolicy[T](orderBook, updated, tickSize, tradable)
@@ -99,6 +113,20 @@ object SealedBidAuction {
     val tradable: T)
       extends SealedBidAuction[T]
       with UniformClearingPolicy[T, SealedBidAuction[T]] {
+
+    /** Combines this `SealedBidAuction` mechanism with some other `SealedBidAuction`.
+      *
+      * @param that
+      * @return
+      * @note this method is necessary in order to parallelize auction simulations.
+      */
+    def combineWith(that: SealedBidAuction[T]): SealedBidAuction[T] = {
+      require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
+      val combinedOrderBooks = orderBook.combineWith(that.orderBook)
+      val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes!
+      val updatedPricingPolicy: PricingPolicy[T] = ???
+      new WithUniformClearingPolicy(combinedOrderBooks, updatedPricingPolicy, updatedTickSize, tradable)
+    }
 
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): SealedBidAuction[T] = {

--- a/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
@@ -74,20 +74,6 @@ object SealedBidAuction {
       extends SealedBidAuction[T]
       with DiscriminatoryClearingPolicy[T, SealedBidAuction[T]] {
 
-    /** Combines this `SealedBidAuction` mechanism with some other `SealedBidAuction`.
-      *
-      * @param that
-      * @return
-      * @note this method is necessary in order to parallelize auction simulations.
-      */
-    def combineWith(that: SealedBidAuction[T]): SealedBidAuction[T] = {
-      require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
-      val combinedOrderBooks = orderBook.combineWith(that.orderBook)
-      val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes!
-      val updatedPricingPolicy: PricingPolicy[T] = ???
-      new WithDiscriminatoryClearingPolicy(combinedOrderBooks, updatedPricingPolicy, updatedTickSize, tradable)
-    }
-
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): SealedBidAuction[T] = {
       new WithDiscriminatoryClearingPolicy[T](orderBook, updated, tickSize, tradable)
@@ -113,20 +99,6 @@ object SealedBidAuction {
     val tradable: T)
       extends SealedBidAuction[T]
       with UniformClearingPolicy[T, SealedBidAuction[T]] {
-
-    /** Combines this `SealedBidAuction` mechanism with some other `SealedBidAuction`.
-      *
-      * @param that
-      * @return
-      * @note this method is necessary in order to parallelize auction simulations.
-      */
-    def combineWith(that: SealedBidAuction[T]): SealedBidAuction[T] = {
-      require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
-      val combinedOrderBooks = orderBook.combineWith(that.orderBook)
-      val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes! overflow!
-      val updatedPricingPolicy: PricingPolicy[T] = ???
-      new WithUniformClearingPolicy(combinedOrderBooks, updatedPricingPolicy, updatedTickSize, tradable)
-    }
 
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): SealedBidAuction[T] = {

--- a/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
@@ -123,7 +123,7 @@ object SealedBidAuction {
     def combineWith(that: SealedBidAuction[T]): SealedBidAuction[T] = {
       require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
       val combinedOrderBooks = orderBook.combineWith(that.orderBook)
-      val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes!
+      val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes! overflow!
       val updatedPricingPolicy: PricingPolicy[T] = ???
       new WithUniformClearingPolicy(combinedOrderBooks, updatedPricingPolicy, updatedTickSize, tradable)
     }

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBook.scala
@@ -19,6 +19,8 @@ import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnit
 import org.economicsl.auctions.{Reference, Token}
 import org.economicsl.core.{Currency, Price, Tradable}
 
+import scala.collection.GenIterable
+
 
 /** Class implementing the four-heap order book algorithm.
   *
@@ -34,8 +36,9 @@ import org.economicsl.core.{Currency, Price, Tradable}
   *       Orders are distinguished by whether or not they are `AskOrder` or `BidOrder` instances, and whether or not
   *       they are in the current matched set.
   */
-final class FourHeapOrderBook[T <: Tradable] private(val matchedOrders: MatchedOrders[T],
-                                                     val unMatchedOrders: UnMatchedOrders[T]) {
+final class FourHeapOrderBook[T <: Tradable] private(
+  val matchedOrders: MatchedOrders[T],
+  val unMatchedOrders: UnMatchedOrders[T]) {
 
   /** If the constructor for `FourHeapOrderBook` becomes public, then this should be changed to require. */
   assert(orderBookInvariantsHold, "FourHeapOrderBook invariants failed!")
@@ -74,8 +77,15 @@ final class FourHeapOrderBook[T <: Tradable] private(val matchedOrders: MatchedO
       None
   }
 
-  def spread: Option[Currency] = {
-    bidPriceQuote.flatMap(bidPrice => askPriceQuote.map(askPrice => bidPrice.value - askPrice.value))
+  def combineWith(that: FourHeapOrderBook[T]): FourHeapOrderBook[T] = {
+    // drain that order book of its matched and unmatched orders...
+    val (withOutMatchedOrders, additionalMatchedOrders) = that.removeAllMatchedOrders
+    val (residualOrderBook, additionalUnMatchedOrders) = withOutMatchedOrders.removeAllUnMatchedOrders
+    assert(residualOrderBook.isEmpty, "After removing all matched and un-matched orders, order book should be empty!")
+
+    // ...and add them to this order book!
+    val withAdditionalMatchedOrders = insert(additionalMatchedOrders)
+    withAdditionalMatchedOrders.insert(additionalUnMatchedOrders)
   }
 
   def insert(kv: (Reference, (Token, SingleUnitOrder[T]))): FourHeapOrderBook[T] = kv match {
@@ -113,6 +123,24 @@ final class FourHeapOrderBook[T <: Tradable] private(val matchedOrders: MatchedO
         case _ =>
           new FourHeapOrderBook(matchedOrders, unMatchedOrders + (reference -> (token -> order)))
       }
+  }
+
+  /** Create a new `FourHeapOrderBook` containing the collection of orders.
+    *
+    * @param kvs
+    * @return
+    * @note depending on the type of collection `kvs` this method might be done in parallel.
+    */
+  def insert(kvs: GenIterable[(Reference, (Token, SingleUnitOrder[T]))]): FourHeapOrderBook[T] = {
+    kvs.aggregate(this)((orderBook, kv) => orderBook.insert(kv), (ob1, ob2) => ob1.combineWith(ob2))
+  }
+
+  def isEmpty: Boolean = {
+    matchedOrders.isEmpty && unMatchedOrders.isEmpty
+  }
+
+  def nonEmpty: Boolean = {
+    !isEmpty
   }
 
   /** Create a new `FourHeapOrderBook` with a given `AskOrder` removed from this order book.
@@ -174,6 +202,18 @@ final class FourHeapOrderBook[T <: Tradable] private(val matchedOrders: MatchedO
   def splitAtTopMatch: (FourHeapOrderBook[T], Option[((Reference, (Token, SingleUnitAskOrder[T])), (Reference, (Token, SingleUnitBidOrder[T])))]) = {
     val (remainingMatchedOrders, topMatchedOrders) = matchedOrders.splitAtTopMatch
     (new FourHeapOrderBook(remainingMatchedOrders, unMatchedOrders), topMatchedOrders)
+  }
+
+  def spread: Option[Currency] = {
+    bidPriceQuote.flatMap(bidPrice => askPriceQuote.map(askPrice => bidPrice.value - askPrice.value))
+  }
+
+  private def removeAllMatchedOrders: (FourHeapOrderBook[T], GenIterable[(Reference, (Token, SingleUnitOrder[T]))]) = {
+    ???
+  }
+
+  private def removeAllUnMatchedOrders: (FourHeapOrderBook[T], GenIterable[(Reference, (Token, SingleUnitOrder[T]))]) = {
+    ???
   }
 
   /**

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
@@ -43,7 +43,8 @@ private[orderbooks] final class MatchedOrders[T <: Tradable](askOrders: SortedAs
   /** The ordering used to sort the `BidOrder` instances contained in this `MatchedOrders` instance. */
   val bidOrdering: Ordering[(Reference, (Token, SingleUnitBidOrder[T]))] = bidOrders.ordering
 
-  val numberUnits: Quantity = askOrders.numberUnits  // or bidOrders.numberUnits!
+  /** Total number of units of the `Tradable` contained in the `MatchedOrders`. */
+  val numberUnits: Quantity = askOrders.numberUnits + bidOrders.numberUnits
 
   /** Create a new `MatchedOrders` instance containing a matched pair of `(AskOrder, BidOrder)` instances.
     *

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/MatchedOrders.scala
@@ -99,6 +99,10 @@ private[orderbooks] final class MatchedOrders[T <: Tradable](askOrders: SortedAs
     askOrders.headOption.flatMap(askOrder => bidOrders.headOption.map(bidOrder => (askOrder, bidOrder)))
   }
 
+  def isEmpty: Boolean = {
+    askOrders.isEmpty && bidOrders.isEmpty
+  }
+
   /** Replace an existing `AskOrder` instance with another `AskOrder` instance.
     *
     * @param existing

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
@@ -17,7 +17,7 @@ package org.economicsl.auctions.singleunit.orderbooks
 
 import org.economicsl.auctions.{Reference, Token}
 import org.economicsl.auctions.singleunit.orders._
-import org.economicsl.core.Tradable
+import org.economicsl.core.{Quantity, Tradable}
 
 
 /** Class for storing sets of unmatched `AskOrder` and `BidOrder` instances.
@@ -40,6 +40,9 @@ final class UnMatchedOrders[T <: Tradable] private(
 
   /** The ordering used to sort the `BidOrder` instances contained in this `UnMatchedOrders` instance. */
   val bidOrdering: Ordering[(Reference, (Token, SingleUnitBidOrder[T]))] = bidOrders.ordering
+
+  /** Total number of units of the `Tradable` contained in the `UnMatchedOrders`. */
+  val numberUnits: Quantity = askOrders.numberUnits + bidOrders.numberUnits
 
   /** Create a new `UnMatchedOrders` instance containing the additional `AskOrder`.
     *
@@ -89,8 +92,18 @@ final class UnMatchedOrders[T <: Tradable] private(
     askOrders.isEmpty && bidOrders.isEmpty
   }
 
+  /**
+    *
+    * @return
+    */
   def tail: UnMatchedOrders[T] = {
-    new UnMatchedOrders(askOrders.tail, bidOrders.tail)
+    if (askOrders.isEmpty) {
+      new UnMatchedOrders(askOrders, bidOrders.tail)
+    } else if (bidOrders.isEmpty) {
+      new UnMatchedOrders(askOrders.tail, bidOrders)
+    } else {
+      new UnMatchedOrders(askOrders.tail, bidOrders.tail)  // with throw exception if empty!
+    }
   }
 
   /* Used to check that highest priced bid order does not match with lowest priced ask order. */

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
@@ -29,8 +29,9 @@ import org.economicsl.core.Tradable
   * @author davidrpugh
   * @since 0.1.0
   */
-final class UnMatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrders[T],
-                                                   val bidOrders: SortedBidOrders[T]) {
+final class UnMatchedOrders[T <: Tradable] private(
+  val askOrders: SortedAskOrders[T],
+  val bidOrders: SortedBidOrders[T]) {
 
   require(heapsNotCrossed, "Limit price of best `BidOrder` must not exceed the limit price of the best `AskOrder`.")
 
@@ -80,11 +81,19 @@ final class UnMatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrder
     askOrders.get(reference).orElse(bidOrders.get(reference))
   }
 
+  def headOption: (Option[(Reference, (Token, SingleUnitAskOrder[T]))], Option[(Reference, (Token, SingleUnitBidOrder[T]))]) = {
+    (askOrders.headOption, bidOrders.headOption)
+  }
+
   def isEmpty: Boolean = {
     askOrders.isEmpty && bidOrders.isEmpty
   }
 
-  /* Used to check this invariant that must hold for all `UnMatchedOrders` instances. */
+  def tail: UnMatchedOrders[T] = {
+    new UnMatchedOrders(askOrders.tail, bidOrders.tail)
+  }
+
+  /* Used to check that highest priced bid order does not match with lowest priced ask order. */
   private[this] def heapsNotCrossed: Boolean = {
     bidOrders.headOption.forall{ case (_, (_, bidOrder)) =>
       askOrders.headOption.forall{ case (_, (_, askOrder)) =>

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
@@ -80,6 +80,10 @@ final class UnMatchedOrders[T <: Tradable] private(val askOrders: SortedAskOrder
     askOrders.get(reference).orElse(bidOrders.get(reference))
   }
 
+  def isEmpty: Boolean = {
+    askOrders.isEmpty && bidOrders.isEmpty
+  }
+
   /* Used to check this invariant that must hold for all `UnMatchedOrders` instances. */
   private[this] def heapsNotCrossed: Boolean = {
     bidOrders.headOption.forall{ case (_, (_, bidOrder)) =>

--- a/src/test/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBookSpec.scala
@@ -51,7 +51,6 @@ class FourHeapOrderBookSpec
     case (orderBook, (reference, askOrder)) => orderBook.insert(reference -> askOrder)
   }
 
-
   "A FourHeapOrderBook" should "be able to insert bid orders" in {
 
     withBids.matchedOrders.numberUnits should be(Quantity.zero)
@@ -89,6 +88,14 @@ class FourHeapOrderBookSpec
         residual
     }
     assert(withOutBids.unMatchedOrders.bidOrders.isEmpty)
+
+  }
+
+  "A FourHeapOrderBook" should "be able to combine with another FourHeapOrderBook" in {
+
+    val withOrders = withBids.combineWith(withOffers)
+    val expectedNumberUnits = withBids.numberUnits + withOffers.numberUnits
+    withOrders.numberUnits should be(expectedNumberUnits)
 
   }
 


### PR DESCRIPTION
This PR adds a `combineWith` method to the `Auction` type that effectively merges an auction with another auction of an appropriate type.  This method will be used to parallelize auction simulations as follows.

```
val orders: ParIterable[(Token, Order[T])] = ???
val withOutOrders: Auction = ???
val withOrders: Auction = orders.aggregate(withOutOrders)((auction, order) => auction.insert(order), (auction1, auction2) => auction1.combineWith(auction2))
```

The real work is being done by the `aggregate` method which is part of the scala collections library.  Finalizing this PR requires implementing some helper methods in the `FourHeapOrderBook` class and addressing an issue with the visibility modifier on the `orderBook` field in the `Auction` type.