### PR TITLE
Refactor auction protocol

### DIFF
--- a/src/functional/java/org/economicsl/auctions/ImperativePeriodicDoubleAuction.java
+++ b/src/functional/java/org/economicsl/auctions/ImperativePeriodicDoubleAuction.java
@@ -26,7 +26,8 @@ public class ImperativePeriodicDoubleAuction {
         // define the auction mechanism...
         TestStock googleStock = new TestStock();
         MidPointPricingPolicy<TestStock> midpointPricingPolicy = new MidPointPricingPolicy<>();
-        OpenBidAuction<TestStock> doubleAuction = OpenBidAuction.withUniformClearingPolicy(midpointPricingPolicy, googleStock);
+        AuctionProtocol<TestStock> protocol = AuctionProtocol$.MODULE$.apply(googleStock);  // todo create JAuctionProtocol?
+        OpenBidAuction<TestStock> doubleAuction = OpenBidAuction.withUniformClearingPolicy(midpointPricingPolicy, protocol);
 
         // generate some random order flow...
         int numberOrders = 10000;

--- a/src/functional/scala/org/economicsl/auctions/singleunit/ContinuousDoubleAuction.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/ContinuousDoubleAuction.scala
@@ -32,8 +32,9 @@ import scala.util.Random
 object ContinuousDoubleAuction extends App {
 
   val google: TestStock = TestStock()
+  val protocol = AuctionProtocol(google)
   val pricingRule = new MidPointPricingPolicy[TestStock]
-  val withDiscriminatoryPricing = OpenBidAuction.withDiscriminatoryClearingPolicy(pricingRule, google)
+  val withDiscriminatoryPricing = OpenBidAuction.withDiscriminatoryClearingPolicy(pricingRule, protocol)
 
   // generate a very large stream of random orders...
   type OrderFlow[T <: Tradable] = Stream[(Token, SingleUnitOrder[T])]

--- a/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceOpenBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceOpenBidAuctionSpec.scala
@@ -47,8 +47,9 @@ class FirstPriceOpenBidAuctionSpec
   val (_, highestPricedBidOrder) = bidOrders.maxBy{ case (_, bidOrder) => bidOrder.limit }
 
   // seller uses a first-priced, open bid auction...
+  val protocol = AuctionProtocol(parkingSpace)
   val firstPriceOpenBidAuction: OpenBidAuction[ParkingSpace] = {
-    OpenBidAuction.withUniformClearingPolicy(AskQuotePricingPolicy[ParkingSpace], parkingSpace)
+    OpenBidAuction.withUniformClearingPolicy(AskQuotePricingPolicy[ParkingSpace], protocol)
   }
 
   // Seller that must sell at any positive price

--- a/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceSealedBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceSealedBidAuctionSpec.scala
@@ -40,8 +40,9 @@ class FirstPriceSealedBidAuctionSpec
   // seller uses a first-priced, sealed bid auction...
   val uuid: UUID = UUID.randomUUID()
   val parkingSpace = ParkingSpace(uuid)
+  val protocol = AuctionProtocol(parkingSpace)
   val firstPriceSealedBidAuction: SealedBidAuction[ParkingSpace] = {
-    SealedBidAuction.withUniformClearingPolicy(AskQuotePricingPolicy[ParkingSpace], parkingSpace)
+    SealedBidAuction.withUniformClearingPolicy(AskQuotePricingPolicy[ParkingSpace], protocol)
   }
 
   // suppose that seller must sell the parking space at any positive price...

--- a/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceSealedBidReverseAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/FirstPriceSealedBidReverseAuctionSpec.scala
@@ -38,8 +38,9 @@ class FirstPriceSealedBidReverseAuctionSpec
 
   // reverse auction to procure a service at lowest possible cost...
   val service = Service()
+  val protocol = AuctionProtocol(service)
   val firstPriceSealedBidReverseAuction: SealedBidAuction[Service] = {
-    SealedBidAuction.withUniformClearingPolicy(BidQuotePricingPolicy[Service], service)
+    SealedBidAuction.withUniformClearingPolicy(BidQuotePricingPolicy[Service], protocol)
   }
 
   // buyer is willing to pay anything...

--- a/src/functional/scala/org/economicsl/auctions/singleunit/PeriodicDoubleAuction.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/PeriodicDoubleAuction.scala
@@ -17,7 +17,7 @@ package org.economicsl.auctions.singleunit
 
 import org.economicsl.auctions.OrderTracker.{Accepted, Rejected}
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
-import org.economicsl.auctions.{OrderGenerator, TestStock, Token}
+import org.economicsl.auctions.{AuctionProtocol, OrderGenerator, TestStock, Token}
 import org.economicsl.auctions.singleunit.pricing.MidPointPricingPolicy
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -41,7 +41,8 @@ class PeriodicDoubleAuction
   "A PeriodicDoubleAuction with uniform pricing" should "produce a single price at which all filled orders are processed." in {
 
     val pricingRule = new MidPointPricingPolicy[TestStock]
-    val withUniformPricing = SealedBidAuction.withUniformClearingPolicy(pricingRule, google)
+    val protocol = AuctionProtocol(google)
+    val withUniformPricing = SealedBidAuction.withUniformClearingPolicy(pricingRule, protocol)
 
     // this whole process is data parallel...
     val (withOrders, _) = {

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceOpenBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceOpenBidAuctionSpec.scala
@@ -21,7 +21,7 @@ import org.economicsl.auctions._
 import org.economicsl.auctions.quotes.AskPriceQuoteRequest
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.auctions.singleunit.pricing.BidQuotePricingPolicy
-import org.economicsl.core.{Currency, Price}
+import org.economicsl.core.Price
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
@@ -38,11 +38,11 @@ class SecondPriceOpenBidAuctionSpec
     with Matchers {
 
   // seller is willing to sell at any positive price...but wants incentive compatible mechanism for buyers!
-  val tickSize: Currency = 1
   val uuid: UUID = UUID.randomUUID()
   val parkingSpace = ParkingSpace(uuid)
+  val protocol = AuctionProtocol(parkingSpace)
   val secondPriceOpenBidAuction: OpenBidAuction[ParkingSpace] = {
-    OpenBidAuction.withUniformClearingPolicy(BidQuotePricingPolicy[ParkingSpace], tickSize, parkingSpace)
+    OpenBidAuction.withUniformClearingPolicy(BidQuotePricingPolicy[ParkingSpace], protocol)
   }
 
   val seller: UUID = UUID.randomUUID()

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidAuctionSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import org.economicsl.auctions._
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.auctions.singleunit.pricing.BidQuotePricingPolicy
-import org.economicsl.core.{Currency, Price}
+import org.economicsl.core.Price
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
@@ -38,11 +38,11 @@ class SecondPriceSealedBidAuctionSpec
     with TokenGenerator {
 
   // seller is willing to sell at any positive price...but wants incentive compatible mechanism for buyers!
-  val tickSize: Currency = 1
   val uuid: UUID = UUID.randomUUID()
   val parkingSpace = ParkingSpace(uuid)
+  val protocol = AuctionProtocol(parkingSpace)
   val secondPriceSealedBidAuction: SealedBidAuction[ParkingSpace] = {
-    SealedBidAuction.withUniformClearingPolicy(BidQuotePricingPolicy[ParkingSpace], tickSize, parkingSpace)
+    SealedBidAuction.withUniformClearingPolicy(BidQuotePricingPolicy[ParkingSpace], protocol)
   }
 
   val seller: UUID = UUID.randomUUID()

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidReverseAuctionSpec.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SecondPriceSealedBidReverseAuctionSpec.scala
@@ -38,8 +38,9 @@ class SecondPriceSealedBidReverseAuctionSpec
 
   // reverse auction to procure a service at lowest possible cost...
   val service = Service()
+  val protocol = AuctionProtocol(service)
   val secondPriceSealedBidReverseAuction: SealedBidAuction[Service] = {
-    SealedBidAuction.withUniformClearingPolicy(AskQuotePricingPolicy[Service], service)
+    SealedBidAuction.withUniformClearingPolicy(AskQuotePricingPolicy[Service], protocol)
   }
 
   // buyer is willing to pay anything...

--- a/src/main/java/org/economicsl/auctions/singleunit/JAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JAuction.java
@@ -36,7 +36,7 @@ public abstract class JAuction<T extends Tradable, A extends JAuction<T, A>> {
     /** Returns an auction of type `A` with a particular pricing policy. */
     public abstract A withPricingPolicy(PricingPolicy<T> updated);
 
-    /** Returns an auction of type `A` with a particular tick size. */
-    public abstract A withTickSize(Long updated);
+    /** Returns an auction of type `A` with a particular protocol. */
+    public abstract A withProtocol(Auction.AuctionProtocol<T> protocol);
 
 }

--- a/src/main/java/org/economicsl/auctions/singleunit/JAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JAuction.java
@@ -1,6 +1,7 @@
 package org.economicsl.auctions.singleunit;
 
 
+import org.economicsl.auctions.AuctionProtocol;
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder;
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy;
 import org.economicsl.core.Tradable;
@@ -37,6 +38,6 @@ public abstract class JAuction<T extends Tradable, A extends JAuction<T, A>> {
     public abstract A withPricingPolicy(PricingPolicy<T> updated);
 
     /** Returns an auction of type `A` with a particular protocol. */
-    public abstract A withProtocol(Auction.AuctionProtocol<T> protocol);
+    public abstract A withProtocol(AuctionProtocol<T> protocol);
 
 }

--- a/src/main/java/org/economicsl/auctions/singleunit/JOpenBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JOpenBidAuction.java
@@ -85,54 +85,32 @@ class JOpenBidAuction<T extends Tradable> extends JAuction<T, JOpenBidAuction<T>
         return new JOpenBidAuction<>(withUpdatedPricingPolicy);
     }
 
-    public JOpenBidAuction<T> withTickSize(Long updated) {
-        OpenBidAuction<T> withUpdatedTickSize = auction.withTickSize(updated);
+    public JOpenBidAuction<T> withProtocol(Auction.AuctionProtocol<T> updated) {
+        OpenBidAuction<T> withUpdatedTickSize = auction.withProtocol(updated);
         return new JOpenBidAuction<>(withUpdatedTickSize);
     }
 
-    /** Factory method for creating sealed-bid auctions with uniform clearing policy.
-     *
-     * @param pricingPolicy
-     * @param tickSize
-     * @param <T>
-     * @return
-     */
-    public static <T extends Tradable> JOpenBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, Long tickSize, T tradable) {
-        OpenBidAuction<T> auction = OpenBidAuction.withUniformClearingPolicy(pricingPolicy, tickSize, tradable);
-        return new JOpenBidAuction<>(auction);
-    }
-
-    /** Factory method for creating sealed-bid auctions with uniform clearing policy.
-     *
-     * @param pricingPolicy
-     * @param <T>
-     * @return
-     */
-    public static <T extends Tradable> JOpenBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, T tradable) {
-        OpenBidAuction<T> auction = OpenBidAuction.withUniformClearingPolicy(pricingPolicy, tradable);
-        return new JOpenBidAuction<>(auction);
-    }
-
     /** Factory method for creating sealed-bid auctons with discriminatory clearing policy.
      *
      * @param pricingPolicy
-     * @param tickSize
+     * @param protocol
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JOpenBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, Long tickSize, T tradable) {
-        OpenBidAuction<T> auction = OpenBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tickSize, tradable);
+    public static <T extends Tradable> JOpenBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+        OpenBidAuction<T> auction = OpenBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, protocol);
         return new JOpenBidAuction<>(auction);
     }
 
-    /** Factory method for creating sealed-bid auctons with discriminatory clearing policy.
+    /** Factory method for creating sealed-bid auctions with uniform clearing policy.
      *
      * @param pricingPolicy
+     * @param protocol
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JOpenBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, T tradable) {
-        OpenBidAuction<T> auction = OpenBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tradable);
+    public static <T extends Tradable> JOpenBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+        OpenBidAuction<T> auction = OpenBidAuction.withUniformClearingPolicy(pricingPolicy, protocol);
         return new JOpenBidAuction<>(auction);
     }
 

--- a/src/main/java/org/economicsl/auctions/singleunit/JOpenBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JOpenBidAuction.java
@@ -16,6 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.singleunit;
 
 
+import org.economicsl.auctions.AuctionProtocol;
 import org.economicsl.auctions.OrderTracker.*;
 import org.economicsl.auctions.SpotContract;
 import org.economicsl.auctions.quotes.Quote;
@@ -85,7 +86,7 @@ class JOpenBidAuction<T extends Tradable> extends JAuction<T, JOpenBidAuction<T>
         return new JOpenBidAuction<>(withUpdatedPricingPolicy);
     }
 
-    public JOpenBidAuction<T> withProtocol(Auction.AuctionProtocol<T> updated) {
+    public JOpenBidAuction<T> withProtocol(AuctionProtocol<T> updated) {
         OpenBidAuction<T> withUpdatedTickSize = auction.withProtocol(updated);
         return new JOpenBidAuction<>(withUpdatedTickSize);
     }
@@ -97,7 +98,7 @@ class JOpenBidAuction<T extends Tradable> extends JAuction<T, JOpenBidAuction<T>
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JOpenBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+    public static <T extends Tradable> JOpenBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, AuctionProtocol<T> protocol) {
         OpenBidAuction<T> auction = OpenBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, protocol);
         return new JOpenBidAuction<>(auction);
     }
@@ -109,7 +110,7 @@ class JOpenBidAuction<T extends Tradable> extends JAuction<T, JOpenBidAuction<T>
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JOpenBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+    public static <T extends Tradable> JOpenBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, AuctionProtocol<T> protocol) {
         OpenBidAuction<T> auction = OpenBidAuction.withUniformClearingPolicy(pricingPolicy, protocol);
         return new JOpenBidAuction<>(auction);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/JSealedBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JSealedBidAuction.java
@@ -16,6 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.singleunit;
 
 
+import org.economicsl.auctions.AuctionProtocol;
 import org.economicsl.auctions.SpotContract;
 import org.economicsl.auctions.OrderTracker.*;
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder;
@@ -79,7 +80,7 @@ class JSealedBidAuction<T extends Tradable> extends JAuction<T, JSealedBidAuctio
         return new JSealedBidAuction<>(withUpdatedPricingPolicy);
     }
 
-    public JSealedBidAuction<T> withProtocol(Auction.AuctionProtocol<T> updated) {
+    public JSealedBidAuction<T> withProtocol(AuctionProtocol<T> updated) {
         SealedBidAuction<T> withUpdatedTickSize = auction.withProtocol(updated);
         return new JSealedBidAuction<>(withUpdatedTickSize);
     }
@@ -91,7 +92,7 @@ class JSealedBidAuction<T extends Tradable> extends JAuction<T, JSealedBidAuctio
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JSealedBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+    public static <T extends Tradable> JSealedBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, AuctionProtocol<T> protocol) {
         SealedBidAuction<T> auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, protocol);
         return new JSealedBidAuction<>(auction);
     }
@@ -103,7 +104,7 @@ class JSealedBidAuction<T extends Tradable> extends JAuction<T, JSealedBidAuctio
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JSealedBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+    public static <T extends Tradable> JSealedBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, AuctionProtocol<T> protocol) {
         SealedBidAuction<T> auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, protocol);
         return new JSealedBidAuction<>(auction);
     }

--- a/src/main/java/org/economicsl/auctions/singleunit/JSealedBidAuction.java
+++ b/src/main/java/org/economicsl/auctions/singleunit/JSealedBidAuction.java
@@ -79,54 +79,32 @@ class JSealedBidAuction<T extends Tradable> extends JAuction<T, JSealedBidAuctio
         return new JSealedBidAuction<>(withUpdatedPricingPolicy);
     }
 
-    public JSealedBidAuction<T> withTickSize(Long updated) {
-        SealedBidAuction<T> withUpdatedTickSize = auction.withTickSize(updated);
+    public JSealedBidAuction<T> withProtocol(Auction.AuctionProtocol<T> updated) {
+        SealedBidAuction<T> withUpdatedTickSize = auction.withProtocol(updated);
         return new JSealedBidAuction<>(withUpdatedTickSize);
     }
 
-    /** Factory method for creating sealed-bid auctions with uniform clearing policy.
-     *
-     * @param pricingPolicy
-     * @param tickSize
-     * @param <T>
-     * @return
-     */
-    public static <T extends Tradable> JSealedBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, Long tickSize, T tradable) {
-        SealedBidAuction<T> auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, tickSize, tradable);
-        return new JSealedBidAuction<>(auction);
-    }
-
-    /** Factory method for creating sealed-bid auctions with uniform clearing policy.
-     *
-     * @param pricingPolicy
-     * @param <T>
-     * @return
-     */
-    public static <T extends Tradable> JSealedBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, T tradable) {
-        SealedBidAuction<T> auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, tradable);
-        return new JSealedBidAuction<>(auction);
-    }
-
     /** Factory method for creating sealed-bid auctons with discriminatory clearing policy.
      *
      * @param pricingPolicy
-     * @param tickSize
+     * @param protocol
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JSealedBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, Long tickSize, T tradable) {
-        SealedBidAuction<T> auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tickSize, tradable);
+    public static <T extends Tradable> JSealedBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+        SealedBidAuction<T> auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, protocol);
         return new JSealedBidAuction<>(auction);
     }
 
-    /** Factory method for creating sealed-bid auctons with discriminatory clearing policy.
+    /** Factory method for creating sealed-bid auctions with uniform clearing policy.
      *
      * @param pricingPolicy
+     * @param protocol
      * @param <T>
      * @return
      */
-    public static <T extends Tradable> JSealedBidAuction<T> withDiscriminatoryClearingPolicy(PricingPolicy<T> pricingPolicy, T tradable) {
-        SealedBidAuction<T> auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tradable);
+    public static <T extends Tradable> JSealedBidAuction<T> withUniformClearingPolicy(PricingPolicy<T> pricingPolicy, Auction.AuctionProtocol<T> protocol) {
+        SealedBidAuction<T> auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, protocol);
         return new JSealedBidAuction<>(auction);
     }
 

--- a/src/main/scala/org/economicsl/auctions/AuctionProtocol.scala
+++ b/src/main/scala/org/economicsl/auctions/AuctionProtocol.scala
@@ -28,3 +28,25 @@ trait AuctionProtocol[+T <: Tradable] {
   def withTickSize(updated: Currency): AuctionProtocol[T]
 
 }
+
+
+object AuctionProtocol {
+
+  def apply[T <: Tradable](tickSize: Currency, tradable: T): AuctionProtocol[T] = {
+    AuctionProtocolImpl(tickSize, tradable)
+  }
+
+  def apply[T <: Tradable](tradable: T): AuctionProtocol[T] = {
+    AuctionProtocolImpl(1L, tradable)
+  }
+
+  private case class AuctionProtocolImpl[+T <: Tradable](tickSize: Currency, tradable: T)
+      extends AuctionProtocol[T] {
+
+    def withTickSize(updated: Currency): AuctionProtocol[T] = {
+      AuctionProtocolImpl(updated, tradable)
+    }
+
+  }
+
+}

--- a/src/main/scala/org/economicsl/auctions/AuctionProtocol.scala
+++ b/src/main/scala/org/economicsl/auctions/AuctionProtocol.scala
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2017 KAPSARC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.economicsl.auctions
+
+import org.economicsl.core.{Currency, Tradable}
+
+
+/** Need some data structure to convey the information about an auction to participants. */
+trait AuctionProtocol[+T <: Tradable] {
+
+  def tickSize: Currency
+
+  def tradable: T
+
+  def withTickSize(updated: Currency): AuctionProtocol[T]
+
+}

--- a/src/main/scala/org/economicsl/auctions/OrderTracker.scala
+++ b/src/main/scala/org/economicsl/auctions/OrderTracker.scala
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package org.economicsl.auctions
 
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.core.Tradable
 import org.economicsl.core.util.Timestamp
 
@@ -95,7 +96,7 @@ object OrderTracker {
     * @author davidrpugh
     * @since 0.2.0
     */
-  final case class CanceledByIssuer(timestamp: Timestamp, token: Token, order: Contract) extends Canceled {
+  final case class CanceledByIssuer(timestamp: Timestamp, token: Token, order: Order[Tradable]) extends Canceled {
     val reason: Reason = IssuerRequestedCancel(order)
   }
 
@@ -116,16 +117,25 @@ object OrderTracker {
 
   }
 
-  final case class IssuerRequestedCancel(order: Contract) extends Reason {
+
+  final case class IssuerRequestedCancel(order: Order[Tradable]) extends Reason {
     val message: String = s"Issuer ${order.issuer} requested cancel."
   }
 
-  final case class InvalidTickSize(order: Contract with SinglePricePoint[Tradable], tickSize: Long) extends Reason {
-    val message: String = s"Limit price of ${order.limit} is not a multiple of the tick size $tickSize"
+
+  final case class InvalidTickSize[+T <: Tradable](
+    order: Order[T] with SinglePricePoint[T],
+    protocol: AuctionProtocol[T])
+      extends Reason {
+    val message: String = s"Limit price of ${order.limit} is not a multiple of the tick size ${protocol.tickSize}."
   }
 
-  final case class InvalidTradable(order: Contract with SinglePricePoint[Tradable], tradable: Tradable) extends Reason {
-    val message: String = s"Order tradable ${order.tradable} must be the same as auction $tradable."
+
+  final case class InvalidTradable[+T <: Tradable](
+    order: Order[T] with SinglePricePoint[T],
+    protocol: AuctionProtocol[T])
+      extends Reason {
+    val message: String = s"Order tradable ${order.tradable} must be the same as auction ${protocol.tradable}."
   }
 
 }

--- a/src/main/scala/org/economicsl/auctions/OrderTracker.scala
+++ b/src/main/scala/org/economicsl/auctions/OrderTracker.scala
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package org.economicsl.auctions
 
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.core.Tradable
 import org.economicsl.core.util.Timestamp
 

--- a/src/main/scala/org/economicsl/auctions/actors/AuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/AuctionActor.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, Terminated}
 import akka.routing.{ActorRefRoutee, BroadcastRoutingLogic, Router}
 import org.economicsl.auctions.{Reference, Token}
 import org.economicsl.auctions.singleunit.Auction
-import org.economicsl.auctions.singleunit.orders.SingleUnitOrder // need to generalize the Auction!
+import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
 import org.economicsl.core.Tradable
 
 
@@ -14,7 +14,6 @@ trait AuctionActor[T <: Tradable, A <: Auction[T, A]]
     extends StackableActor {
 
   import AuctionActor._
-  import AuctionParticipantActor._
 
   var auction: A
 
@@ -62,7 +61,7 @@ trait AuctionActor[T <: Tradable, A <: Auction[T, A]]
   protected def registerAuctionParticipants: Receive = {
     case RegisterAuctionParticipant(participant) =>
       context.watch(participant)  // now `AuctionActor` will be notified if `AuctionParticipantActor` "dies"...
-      participant ! AuctionProtocol(auction.tickSize, auction.tradable)
+      participant ! auction.protocol
       participants = participants + participant
       ticker = ticker.addRoutee(participant)
     case DeregisterAuctionParticipant(participant) =>

--- a/src/main/scala/org/economicsl/auctions/actors/AuctionParticipantActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/AuctionParticipantActor.scala
@@ -18,7 +18,8 @@ package org.economicsl.auctions.actors
 
 import akka.actor.ActorRef
 import org.economicsl.auctions.AuctionParticipant
-import org.economicsl.core.{Currency, Tradable}
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
+import org.economicsl.core.Tradable
 
 
 /** Base trait for all `AuctionParticipant` actors.
@@ -33,26 +34,16 @@ trait AuctionParticipantActor[A <: AuctionParticipant[A]]
     extends OrderTrackingActor[A]
     with OrderIssuingActor[A] {
 
-  import AuctionParticipantActor._
-
   override def receive: Receive = {
-    case protocol : AuctionProtocol =>
+    case protocol : AuctionProtocol[Tradable] =>
       auctions = auctions + (sender() -> protocol)
     case message =>
       super.receive(message)
   }
 
   /* An `AuctionParticipant` needs to keep track of multiple auction protocols. */
-  protected var auctions: Map[ActorRef, AuctionProtocol]
+  protected var auctions: Map[ActorRef, AuctionProtocol[Tradable]]
 
   protected var auctionParticipant: A
-
-}
-
-
-object AuctionParticipantActor {
-
-  /** Need some data structure to convey the information about an auction to participants. */
-  final case class AuctionProtocol(tickSize: Currency, tradable: Tradable)
 
 }

--- a/src/main/scala/org/economicsl/auctions/actors/AuctionParticipantActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/AuctionParticipantActor.scala
@@ -17,8 +17,7 @@ package org.economicsl.auctions.actors
 
 
 import akka.actor.ActorRef
-import org.economicsl.auctions.AuctionParticipant
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
+import org.economicsl.auctions.{AuctionParticipant, AuctionProtocol}
 import org.economicsl.core.Tradable
 
 

--- a/src/main/scala/org/economicsl/auctions/actors/ContinuousAuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/ContinuousAuctionActor.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.actors
 
 import akka.actor.{ActorRef, Props}
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
+import org.economicsl.auctions.AuctionProtocol
 import org.economicsl.auctions.singleunit.{Auction, SealedBidAuction}
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
 import org.economicsl.core.Tradable

--- a/src/main/scala/org/economicsl/auctions/actors/ContinuousAuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/ContinuousAuctionActor.scala
@@ -16,9 +16,10 @@ limitations under the License.
 package org.economicsl.auctions.actors
 
 import akka.actor.{ActorRef, Props}
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.{Auction, SealedBidAuction}
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
-import org.economicsl.core.{Currency, Tradable}
+import org.economicsl.core.Tradable
 
 
 trait ContinuousAuctionActor[T <: Tradable, A <: Auction[T, A]]
@@ -30,21 +31,19 @@ object ContinuousAuctionActor {
 
   def withDiscriminatoryClearingPolicy[T <: Tradable]
                                       (pricingPolicy: PricingPolicy[T],
-                                       settlementService: ActorRef,
-                                       tickSize: Currency,
-                                       tradable: T)
+                                       protocol: AuctionProtocol[T],
+                                       settlementService: ActorRef)
                                       : Props = {
-    val auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tickSize, tradable)
+    val auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, protocol)
     Props(new ContinuousAuctionActorImpl(auction, Some(settlementService)))
   }
 
   def withUniformClearingPolicy[T <: Tradable]
                                (pricingPolicy: PricingPolicy[T],
-                                settlementService: ActorRef,
-                                tickSize: Currency,
-                                tradable: T)
+                                protocol: AuctionProtocol[T],
+                                settlementService: ActorRef)
                                : Props = {
-    val auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, tickSize, tradable)
+    val auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, protocol)
     Props(new ContinuousAuctionActorImpl(auction, Some(settlementService)))
   }
 

--- a/src/main/scala/org/economicsl/auctions/actors/PeriodicAuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/PeriodicAuctionActor.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.actors
 
 import akka.actor.{ActorRef, Props}
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
+import org.economicsl.auctions.AuctionProtocol
 import org.economicsl.auctions.singleunit.{Auction, SealedBidAuction}
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
 import org.economicsl.core.Tradable

--- a/src/main/scala/org/economicsl/auctions/actors/PeriodicAuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/PeriodicAuctionActor.scala
@@ -16,9 +16,10 @@ limitations under the License.
 package org.economicsl.auctions.actors
 
 import akka.actor.{ActorRef, Props}
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.{Auction, SealedBidAuction}
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
-import org.economicsl.core.{Currency, Tradable}
+import org.economicsl.core.Tradable
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -34,11 +35,10 @@ object PeriodicAuctionActor {
                                       (initialDelay: FiniteDuration,
                                        interval: FiniteDuration,
                                        pricingPolicy: PricingPolicy[T],
-                                       settlementService: ActorRef,
-                                       tickSize: Currency,
-                                       tradable: T)
+                                       protocol: AuctionProtocol[T],
+                                       settlementService: ActorRef)
                                        : Props = {
-    val auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, tickSize, tradable)
+    val auction = SealedBidAuction.withDiscriminatoryClearingPolicy(pricingPolicy, protocol)
     Props(new PeriodicAuctionActorImpl(auction, initialDelay, interval, Some(settlementService)))
   }
 
@@ -46,11 +46,10 @@ object PeriodicAuctionActor {
                                (initialDelay: FiniteDuration,
                                 interval: FiniteDuration,
                                 pricingPolicy: PricingPolicy[T],
-                                settlementService: ActorRef,
-                                tickSize: Currency,
-                                tradable: T)
+                                protocol: AuctionProtocol[T],
+                                settlementService: ActorRef)
                                 : Props = {
-    val auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, tickSize, tradable)
+    val auction = SealedBidAuction.withUniformClearingPolicy(pricingPolicy, protocol)
     Props(new PeriodicAuctionActorImpl(auction, initialDelay, interval, Some(settlementService)))
   }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -16,12 +16,11 @@ limitations under the License.
 package org.economicsl.auctions.singleunit
 
 import org.economicsl.auctions._
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
 import org.economicsl.core.util.Timestamper
-import org.economicsl.core.{Currency, Tradable}
+import org.economicsl.core.Tradable
 
 
 /** Base trait for all auction implementations.
@@ -124,21 +123,6 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
   protected val orderBook: FourHeapOrderBook[T]
 
   protected val pricingPolicy: PricingPolicy[T]
-
-}
-
-
-object Auction {
-
-  /** Need some data structure to convey the information about an auction to participants. */
-  final case class AuctionProtocol[+T <: Tradable](tickSize: Currency, tradable: T) {
-
-    def withTickSize(updated: Currency): AuctionProtocol[T] = {
-      AuctionProtocol(updated, tradable)
-    }
-
-  }
-
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -16,6 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.singleunit
 
 import org.economicsl.auctions._
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
@@ -73,11 +74,12 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
     * @note this method is necessary in order to parallelize auction simulations.
     */
   def combineWith(that: A): A = {
-    require(tradable.equals(that.tradable), "Auctions can only be combined if they are for the same Tradable!")
+    require(protocol.tradable.equals(that.protocol.tradable), "Only auctions for the same Tradable can be combined!")
     val combinedOrderBooks = orderBook.combineWith(that.orderBook)
     val withCombinedOrderBooks = withOrderBook(combinedOrderBooks)
-    val updatedTickSize = tickSize * that.tickSize  // todo compute least-common-multiple of tick sizes! overflow!
-    withCombinedOrderBooks.withTickSize(updatedTickSize)
+    val combinedTickSize = protocol.tickSize * that.protocol.tickSize  // todo compute least-common-multiple of tick sizes! overflow!
+    val updatedProtocol = protocol.withTickSize(combinedTickSize)
+    withCombinedOrderBooks.withProtocol(updatedProtocol)
   }
 
   /** Create a new instance of type class `A` whose order book contains an additional `BidOrder`.
@@ -89,14 +91,14 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
     *         instances.
     */
   def insert(kv: (Token, SingleUnitOrder[T])): (A, Either[Rejected, Accepted]) = kv match {
-    case (token, order) if order.limit.value % tickSize > 0 =>
+    case (token, order) if order.limit.value % protocol.tickSize > 0 =>
       val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
-      val reason = InvalidTickSize(order, tickSize)
+      val reason = InvalidTickSize(order, protocol)
       val rejected = Rejected(timestamp, token, order, reason)
       (this, Left(rejected))
-    case (token, order) if !order.tradable.equals(tradable) =>
+    case (token, order) if !order.tradable.equals(protocol.tradable) =>
       val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
-      val reason = InvalidTradable(order, tradable)
+      val reason = InvalidTradable(order, protocol)
       val rejected = Rejected(timestamp, token, order, reason)
       (this, Left(rejected))
     case (token, order) =>
@@ -107,15 +109,14 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
       (withOrderBook(updatedOrderBook), Right(accepted))
   }
 
-  def tickSize: Currency
-
-  def tradable: T
+  /** An `Auction` must have some protocol that contains all relevant information about auction. */
+  def protocol: AuctionProtocol[T]
 
   /** Returns an auction of type `A` that encapsulates the current auction state but with a new pricing policy. */
   def withPricingPolicy(updated: PricingPolicy[T]): A
 
-  /** Returns an auction of type `A` the encapsulates the current auction state but with a new tick size. */
-  def withTickSize(updated: Currency): A
+  /** Returns an auction of type `A` that encapsulates the current auction state but with a new protocol. */
+  def withProtocol(updated: AuctionProtocol[T]): A
 
   /** Factory method used by sub-classes to create an `A`. */
   protected def withOrderBook(updated: FourHeapOrderBook[T]): A
@@ -123,6 +124,21 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
   protected val orderBook: FourHeapOrderBook[T]
 
   protected val pricingPolicy: PricingPolicy[T]
+
+}
+
+
+object Auction {
+
+  /** Need some data structure to convey the information about an auction to participants. */
+  final case class AuctionProtocol[+T <: Tradable](tickSize: Currency, tradable: T) {
+
+    def withTickSize(updated: Currency): AuctionProtocol[T] = {
+      AuctionProtocol(updated, tradable)
+    }
+
+  }
+
 
 }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuction.scala
@@ -16,10 +16,11 @@ limitations under the License.
 package org.economicsl.auctions.singleunit
 
 import org.economicsl.auctions.quotes.{Quote, QuoteRequest}
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.clearing.{DiscriminatoryClearingPolicy, UniformClearingPolicy}
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
-import org.economicsl.core.{Currency, Tradable}
+import org.economicsl.core.Tradable
 
 
 /** Base trait for all "Open-bid" auction implementations.
@@ -46,53 +47,40 @@ abstract class OpenBidAuction[T <: Tradable]
 object OpenBidAuction {
 
   def withDiscriminatoryClearingPolicy[T <: Tradable]
-                                      (pricingPolicy: PricingPolicy[T], tickSize: Currency, tradable: T)
+                                      (pricingPolicy: PricingPolicy[T], protocol: AuctionProtocol[T])
                                       : OpenBidAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, tickSize, tradable)
-  }
-
-  def withDiscriminatoryClearingPolicy[T <: Tradable]
-                                      (pricingPolicy: PricingPolicy[T], tradable: T)
-                                      : OpenBidAuction[T] = {
-    val orderBook = FourHeapOrderBook.empty[T]
-    new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, 1L, tradable)
+    new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, protocol)
   }
 
   def withUniformClearingPolicy[T <: Tradable]
-                               (pricingPolicy: PricingPolicy[T], tickSize: Currency, tradable: T)
+                               (pricingPolicy: PricingPolicy[T], protocol: AuctionProtocol[T])
                                : OpenBidAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithUniformClearingPolicy[T](orderBook, pricingPolicy, tickSize, tradable)
-  }
-
-  def withUniformClearingPolicy[T <: Tradable](pricingPolicy: PricingPolicy[T], tradable: T): OpenBidAuction[T] = {
-    val orderBook = FourHeapOrderBook.empty[T]
-    new WithUniformClearingPolicy[T](orderBook, pricingPolicy, 1L, tradable)
+    new WithUniformClearingPolicy[T](orderBook, pricingPolicy, protocol)
   }
 
 
   private class WithDiscriminatoryClearingPolicy[T <: Tradable](
     protected val orderBook: FourHeapOrderBook[T],
     protected val pricingPolicy: PricingPolicy[T],
-    val tickSize: Currency,
-    val tradable: T)
+    val protocol: AuctionProtocol[T])
       extends OpenBidAuction[T]
       with DiscriminatoryClearingPolicy[T, OpenBidAuction[T]] {
 
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): OpenBidAuction[T] = {
-      new WithDiscriminatoryClearingPolicy[T](orderBook, updated, tickSize, tradable)
+      new WithDiscriminatoryClearingPolicy[T](orderBook, updated, protocol)
     }
 
-    /** Returns an auction of type `A` with a particular tick size. */
-    def withTickSize(updated: Currency): OpenBidAuction[T] = {
-      new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, updated, tradable)
+    /** Returns an auction of type `A` that encapsulates the current auction state but with a new protocol. */
+    def withProtocol(updated: AuctionProtocol[T]): OpenBidAuction[T] = {
+      new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, updated)
     }
 
     /** Factory method used by sub-classes to create an `Auction` of type `A`. */
     protected def withOrderBook(updated: FourHeapOrderBook[T]): OpenBidAuction[T] = {
-      new WithDiscriminatoryClearingPolicy[T](updated, pricingPolicy, tickSize, tradable)
+      new WithDiscriminatoryClearingPolicy[T](updated, pricingPolicy, protocol)
     }
 
   }
@@ -101,24 +89,23 @@ object OpenBidAuction {
   private class WithUniformClearingPolicy[T <: Tradable](
     protected val orderBook: FourHeapOrderBook[T],
     protected val pricingPolicy: PricingPolicy[T],
-    val tickSize: Currency,
-    val tradable: T)
+    val protocol: AuctionProtocol[T])
       extends OpenBidAuction[T]
       with UniformClearingPolicy[T, OpenBidAuction[T]] {
 
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): OpenBidAuction[T] = {
-      new WithUniformClearingPolicy[T](orderBook, updated, tickSize, tradable)
+      new WithUniformClearingPolicy[T](orderBook, updated, protocol)
     }
 
-    /** Returns an auction of type `A` with a particular tick size. */
-    def withTickSize(updated: Currency): OpenBidAuction[T] = {
-      new WithUniformClearingPolicy[T](orderBook, pricingPolicy, updated, tradable)
+    /** Returns an auction of type `A` that encapsulates the current auction state but with a new protocol. */
+    def withProtocol(updated: AuctionProtocol[T]): OpenBidAuction[T] = {
+      new WithUniformClearingPolicy[T](orderBook, pricingPolicy, updated)
     }
 
     /** Factory method used by sub-classes to create an `Auction` of type `A`. */
     protected def withOrderBook(updated: FourHeapOrderBook[T]): OpenBidAuction[T] = {
-      new WithUniformClearingPolicy[T](updated, pricingPolicy, tickSize, tradable)
+      new WithUniformClearingPolicy[T](updated, pricingPolicy, protocol)
     }
 
   }

--- a/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/OpenBidAuction.scala
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package org.economicsl.auctions.singleunit
 
+import org.economicsl.auctions.AuctionProtocol
 import org.economicsl.auctions.quotes.{Quote, QuoteRequest}
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.clearing.{DiscriminatoryClearingPolicy, UniformClearingPolicy}
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy

--- a/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
@@ -15,10 +15,11 @@ limitations under the License.
 */
 package org.economicsl.auctions.singleunit
 
+import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
 import org.economicsl.auctions.singleunit.clearing.{DiscriminatoryClearingPolicy, UniformClearingPolicy}
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy
-import org.economicsl.core.{Currency, Tradable}
+import org.economicsl.core.Tradable
 
 
 /** Base trait for all "sealed-bid" auction mechanisms.
@@ -40,53 +41,40 @@ abstract class SealedBidAuction[T <: Tradable]
 object SealedBidAuction {
 
   def withDiscriminatoryClearingPolicy[T <: Tradable]
-                                      (pricingPolicy: PricingPolicy[T], tickSize: Currency, tradable: T)
+                                      (pricingPolicy: PricingPolicy[T], protocol: AuctionProtocol[T])
                                       : SealedBidAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, tickSize, tradable)
-  }
-
-  def withDiscriminatoryClearingPolicy[T <: Tradable]
-                                      (pricingPolicy: PricingPolicy[T], tradable: T)
-                                      : SealedBidAuction[T] = {
-    val orderBook = FourHeapOrderBook.empty[T]
-    new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, 1L, tradable)
+    new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, protocol)
   }
 
   def withUniformClearingPolicy[T <: Tradable]
-                               (pricingPolicy: PricingPolicy[T], tickSize: Currency, tradable: T)
+                               (pricingPolicy: PricingPolicy[T], protocol: AuctionProtocol[T])
                                : SealedBidAuction[T] = {
     val orderBook = FourHeapOrderBook.empty[T]
-    new WithUniformClearingPolicy[T](orderBook, pricingPolicy, tickSize, tradable)
-  }
-
-  def withUniformClearingPolicy[T <: Tradable](pricingPolicy: PricingPolicy[T], tradable: T): SealedBidAuction[T] = {
-    val orderBook = FourHeapOrderBook.empty[T]
-    new WithUniformClearingPolicy[T](orderBook, pricingPolicy, 1L, tradable)
+    new WithUniformClearingPolicy[T](orderBook, pricingPolicy, protocol)
   }
 
 
   private class WithDiscriminatoryClearingPolicy[T <: Tradable](
     protected val orderBook: FourHeapOrderBook[T],
     protected val pricingPolicy: PricingPolicy[T],
-    val tickSize: Currency,
-    val tradable: T)
+    val protocol: AuctionProtocol[T])
       extends SealedBidAuction[T]
       with DiscriminatoryClearingPolicy[T, SealedBidAuction[T]] {
 
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): SealedBidAuction[T] = {
-      new WithDiscriminatoryClearingPolicy[T](orderBook, updated, tickSize, tradable)
+      new WithDiscriminatoryClearingPolicy[T](orderBook, updated, protocol)
     }
 
-    /** Returns an auction of type `A` with a particular tick size. */
-    def withTickSize(updated: Currency): SealedBidAuction[T] = {
-      new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, updated, tradable)
+    /** Returns an auction of type `A` that encapsulates the current auction state but with a new protocol. */
+    def withProtocol(updated: AuctionProtocol[T]): SealedBidAuction[T] = {
+      new WithDiscriminatoryClearingPolicy[T](orderBook, pricingPolicy, updated)
     }
 
     /** Factory method used by sub-classes to create an `Auction` of type `A`. */
     protected def withOrderBook(updated: FourHeapOrderBook[T]): SealedBidAuction[T] = {
-      new WithDiscriminatoryClearingPolicy[T](updated, pricingPolicy, tickSize, tradable)
+      new WithDiscriminatoryClearingPolicy[T](updated, pricingPolicy, protocol)
     }
 
   }
@@ -95,24 +83,23 @@ object SealedBidAuction {
   private class WithUniformClearingPolicy[T <: Tradable](
     protected val orderBook: FourHeapOrderBook[T],
     protected val pricingPolicy: PricingPolicy[T],
-    val tickSize: Currency,
-    val tradable: T)
+    val protocol: AuctionProtocol[T])
       extends SealedBidAuction[T]
       with UniformClearingPolicy[T, SealedBidAuction[T]] {
 
     /** Returns an auction of type `A` with a particular pricing policy. */
     def withPricingPolicy(updated: PricingPolicy[T]): SealedBidAuction[T] = {
-      new WithUniformClearingPolicy[T](orderBook, updated, tickSize, tradable)
+      new WithUniformClearingPolicy[T](orderBook, updated, protocol)
     }
 
-    /** Returns an auction of type `A` with a particular tick size. */
-    def withTickSize(updated: Currency): SealedBidAuction[T] = {
-      new WithUniformClearingPolicy[T](orderBook, pricingPolicy, updated, tradable)
+    /** Returns an auction of type `A` that encapsulates the current auction state but with a new protocol. */
+    def withProtocol(updated: AuctionProtocol[T]): SealedBidAuction[T] = {
+      new WithUniformClearingPolicy[T](orderBook, pricingPolicy, updated)
     }
 
     /** Factory method used by sub-classes to create an `Auction` of type `A`. */
     protected def withOrderBook(updated: FourHeapOrderBook[T]): SealedBidAuction[T] = {
-      new WithUniformClearingPolicy[T](updated, pricingPolicy, tickSize, tradable)
+      new WithUniformClearingPolicy[T](updated, pricingPolicy, protocol)
     }
 
   }

--- a/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/SealedBidAuction.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package org.economicsl.auctions.singleunit
 
-import org.economicsl.auctions.singleunit.Auction.AuctionProtocol
+import org.economicsl.auctions.AuctionProtocol
 import org.economicsl.auctions.singleunit.clearing.{DiscriminatoryClearingPolicy, UniformClearingPolicy}
 import org.economicsl.auctions.singleunit.orderbooks.FourHeapOrderBook
 import org.economicsl.auctions.singleunit.pricing.PricingPolicy

--- a/src/test/scala/org/economicsl/auctions/actors/TestAuctionParticipantActor.scala
+++ b/src/test/scala/org/economicsl/auctions/actors/TestAuctionParticipantActor.scala
@@ -16,15 +16,15 @@ limitations under the License.
 package org.economicsl.auctions.actors
 
 import akka.actor.{ActorRef, Props}
-import org.economicsl.auctions.Issuer
-import org.economicsl.auctions.actors.AuctionParticipantActor.AuctionProtocol
+import org.economicsl.auctions.{AuctionProtocol, Issuer}
 import org.economicsl.auctions.singleunit.TestAuctionParticipant
+import org.economicsl.core.Tradable
 
 
 class TestAuctionParticipantActor private(var auctionParticipant: TestAuctionParticipant)
     extends AuctionParticipantActor[TestAuctionParticipant] {
 
-  protected var auctions: Map[ActorRef, AuctionProtocol] = Map.empty[ActorRef, AuctionProtocol]
+  protected var auctions: Map[ActorRef, AuctionProtocol[Tradable]] = Map.empty[ActorRef, AuctionProtocol[Tradable]]
 
 }
 


### PR DESCRIPTION
Moved auction protocol to top-level package. An `AuctionProtocol` will be used to configure `Auction` types and should contain information that will be shared with `AuctionParticipant` instances.