### PR TITLE
Hotfix token reference

### DIFF
--- a/src/functional/scala/org/economicsl/auctions/singleunit/SingleUnitAuctionSimulation.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SingleUnitAuctionSimulation.scala
@@ -15,10 +15,11 @@ limitations under the License.
 */
 package org.economicsl.auctions.singleunit
 
+import org.economicsl.auctions.messages.OrderId
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
 import org.economicsl.auctions.singleunit.participants.SingleUnitAuctionParticipant
 import org.economicsl.auctions.singleunit.pricing.{AskQuotePricingPolicy, BidQuotePricingPolicy}
-import org.economicsl.auctions.{AuctionProtocol, Contract, SpotContract, OrderId}
+import org.economicsl.auctions.{AuctionProtocol, Contract, SpotContract}
 import org.economicsl.core.{Currency, Tradable}
 
 

--- a/src/functional/scala/org/economicsl/auctions/singleunit/SingleUnitAuctionSimulation.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/SingleUnitAuctionSimulation.scala
@@ -18,14 +18,14 @@ package org.economicsl.auctions.singleunit
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
 import org.economicsl.auctions.singleunit.participants.SingleUnitAuctionParticipant
 import org.economicsl.auctions.singleunit.pricing.{AskQuotePricingPolicy, BidQuotePricingPolicy}
-import org.economicsl.auctions.{AuctionProtocol, Contract, SpotContract, Token}
+import org.economicsl.auctions.{AuctionProtocol, Contract, SpotContract, OrderId}
 import org.economicsl.core.{Currency, Tradable}
 
 
 trait SingleUnitAuctionSimulation {
 
   /** Type used to represent a tuple matching an auction participant with its issued order. */
-  type IssuedOrder[+T <: Tradable] = (SingleUnitAuctionParticipant, (Token, SingleUnitOrder[T]))
+  type IssuedOrder[+T <: Tradable] = (SingleUnitAuctionParticipant, (OrderId, SingleUnitOrder[T]))
 
   /** Type representing the state of an auction simulation. */
   type State[T <: Tradable, A <: Auction[T, A]] = (A, Iterable[SingleUnitAuctionParticipant])
@@ -52,7 +52,7 @@ trait SingleUnitAuctionSimulation {
     * @return
     */
   def insertOrders[T <: Tradable, A <: Auction[T, A]]
-                  (auction: A, issuedOrders: Iterable[(SingleUnitAuctionParticipant, (Token, SingleUnitOrder[T]))])
+                  (auction: A, issuedOrders: Iterable[(SingleUnitAuctionParticipant, (OrderId, SingleUnitOrder[T]))])
                   : (A, Iterable[SingleUnitAuctionParticipant]) = {
     issuedOrders.aggregate((auction, Seq.empty[SingleUnitAuctionParticipant]))(update[T, A], combine[T, A])
   }

--- a/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitBuyer.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitBuyer.scala
@@ -32,9 +32,9 @@ import org.economicsl.core.{Price, Tradable}
   * @since 0.2.0
   */
 class SingleUnitBuyer private(
-  val issuer: Issuer,
-  val outstandingOrders: Map[Token, (Reference, Order[Tradable])],
-  val valuations: Map[Tradable, Price])
+                               val issuer: Issuer,
+                               val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+                               val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
   /** Returns a new `AuctionParticipant` that has observed the `AuctionDataResponse`.
@@ -53,9 +53,9 @@ class SingleUnitBuyer private(
     * @return
     * @note
     */
-  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitBuyer, (Token, SingleUnitBidOrder[T]))] = {
+  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitBuyer, (OrderId, SingleUnitBidOrder[T]))] = {
     val valuation = valuations(protocol.tradable)
-    Some((this, (randomToken(), SingleUnitBidOrder(issuer, valuation, protocol.tradable))))
+    Some((this, (randomOrderId(), SingleUnitBidOrder(issuer, valuation, protocol.tradable))))
   }
 
   /** Request auction data given some `AuctionProtocol`.
@@ -64,12 +64,12 @@ class SingleUnitBuyer private(
     * @tparam T
     * @return
     */
-  def requestAuctionData[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitBuyer, (Token, AuctionDataRequest[T]))] = {
+  def requestAuctionData[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitBuyer, (OrderId, AuctionDataRequest[T]))] = {
     None
   }
 
   /** Creates a new `SingleUnitBuyer` with an `updated` collection of outstanding orders. */
-  protected def withOutstandingOrders(updated: Map[Token, (Reference, Order[Tradable])]): SingleUnitBuyer = {
+  protected def withOutstandingOrders(updated: Map[OrderId, (OrderReferenceId, Order[Tradable])]): SingleUnitBuyer = {
     new SingleUnitBuyer(issuer, updated, valuations)
   }
 
@@ -89,13 +89,13 @@ class SingleUnitBuyer private(
 object SingleUnitBuyer {
 
   def apply(issuer: Issuer, valuations: Map[Tradable, Price]): SingleUnitBuyer = {
-    val outstandingOrders = Map.empty[Token, (Reference, Order[Tradable])]
+    val outstandingOrders = Map.empty[OrderId, (OrderReferenceId, Order[Tradable])]
     new SingleUnitBuyer(issuer, outstandingOrders, valuations)
   }
 
   def apply(valuations: Map[Tradable, Price]): SingleUnitBuyer = {
     val issuer = UUID.randomUUID()
-    val outstandingOrders = Map.empty[Token, (Reference, Order[Tradable])]
+    val outstandingOrders = Map.empty[OrderId, (OrderReferenceId, Order[Tradable])]
     new SingleUnitBuyer(issuer, outstandingOrders, valuations)
   }
 

--- a/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitBuyer.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitBuyer.scala
@@ -25,16 +25,16 @@ import org.economicsl.core.{Price, Tradable}
 
 /** Class used to model an auction participant that issues `SingleUnitBidOrder`.
   *
-  * @param issuer
+  * @param participantId
   * @param outstandingOrders
   * @param valuations
   * @author davidrpugh
   * @since 0.2.0
   */
 class SingleUnitBuyer private(
-  val issuer: Issuer,
-  val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
-  val valuations: Map[Tradable, Price])
+                               val participantId: Issuer,
+                               val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+                               val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
   /** Returns a new `AuctionParticipant` that has observed the `AuctionDataResponse`.
@@ -55,7 +55,7 @@ class SingleUnitBuyer private(
     */
   def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitBuyer, (OrderId, SingleUnitBidOrder[T]))] = {
     val valuation = valuations(protocol.tradable)
-    Some((this, (randomOrderId(), SingleUnitBidOrder(issuer, valuation, protocol.tradable))))
+    Some((this, (randomOrderId(), SingleUnitBidOrder(participantId, valuation, protocol.tradable))))
   }
 
   /** Request auction data given some `AuctionProtocol`.
@@ -70,12 +70,12 @@ class SingleUnitBuyer private(
 
   /** Creates a new `SingleUnitBuyer` with an `updated` collection of outstanding orders. */
   protected def withOutstandingOrders(updated: Map[OrderId, (OrderReferenceId, Order[Tradable])]): SingleUnitBuyer = {
-    new SingleUnitBuyer(issuer, updated, valuations)
+    new SingleUnitBuyer(participantId, updated, valuations)
   }
 
   /** Creates a new `SingleUnitBuyer` with `updated` valuations. */
   protected def withValuations(updated: Map[Tradable, Price]): SingleUnitBuyer = {
-    new SingleUnitBuyer(issuer, outstandingOrders, updated)
+    new SingleUnitBuyer(participantId, outstandingOrders, updated)
   }
 
 }

--- a/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitBuyer.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitBuyer.scala
@@ -18,7 +18,7 @@ package org.economicsl.auctions.singleunit.participants
 import java.util.UUID
 
 import org.economicsl.auctions._
-import org.economicsl.auctions.messages.{AuctionDataRequest, AuctionDataResponse}
+import org.economicsl.auctions.messages.{AuctionDataRequest, AuctionDataResponse, OrderId, OrderReferenceId}
 import org.economicsl.auctions.singleunit.orders.SingleUnitBidOrder
 import org.economicsl.core.{Price, Tradable}
 
@@ -32,9 +32,9 @@ import org.economicsl.core.{Price, Tradable}
   * @since 0.2.0
   */
 class SingleUnitBuyer private(
-                               val issuer: Issuer,
-                               val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
-                               val valuations: Map[Tradable, Price])
+  val issuer: Issuer,
+  val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+  val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
   /** Returns a new `AuctionParticipant` that has observed the `AuctionDataResponse`.

--- a/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitSeller.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitSeller.scala
@@ -24,9 +24,9 @@ import org.economicsl.core.{Price, Tradable}
 
 
 class SingleUnitSeller private(
-  val issuer: Issuer,
-  val outstandingOrders: Map[Token, (Reference, Order[Tradable])],
-  val valuations: Map[Tradable, Price])
+                                val issuer: Issuer,
+                                val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+                                val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
 
@@ -46,9 +46,9 @@ class SingleUnitSeller private(
     * @return
     * @note
     */
-  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitSeller,(Token, SingleUnitAskOrder[T]))] = {
+  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitSeller,(OrderId, SingleUnitAskOrder[T]))] = {
     val valuation = valuations(protocol.tradable)
-    Some((this, (randomToken(), SingleUnitAskOrder(issuer, valuation, protocol.tradable))))
+    Some((this, (randomOrderId(), SingleUnitAskOrder(issuer, valuation, protocol.tradable))))
   }
 
   /** Request auction data given some `AuctionProtocol`.
@@ -57,12 +57,12 @@ class SingleUnitSeller private(
     * @tparam T
     * @return
     */
-  def requestAuctionData[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitSeller, (Token, AuctionDataRequest[T]))] = {
+  def requestAuctionData[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitSeller, (OrderId, AuctionDataRequest[T]))] = {
     None
   }
 
   /** Creates a new `SingleUnitSeller` with an `updated` collection of outstanding orders. */
-  protected def withOutstandingOrders(updated: Map[Token, (Reference, Order[Tradable])]): SingleUnitSeller = {
+  protected def withOutstandingOrders(updated: Map[OrderId, (OrderReferenceId, Order[Tradable])]): SingleUnitSeller = {
     new SingleUnitSeller(issuer, updated, valuations)
   }
 
@@ -82,13 +82,13 @@ class SingleUnitSeller private(
 object SingleUnitSeller {
 
   def apply(issuer: Issuer, valuations: Map[Tradable, Price]): SingleUnitSeller = {
-    val outstandingOrders = Map.empty[Token, (Reference, Order[Tradable])]
+    val outstandingOrders = Map.empty[OrderId, (OrderReferenceId, Order[Tradable])]
     new SingleUnitSeller(issuer, outstandingOrders, valuations)
   }
 
   def apply(valuations: Map[Tradable, Price]): SingleUnitSeller = {
     val issuer = UUID.randomUUID()
-    val outstandingOrders = Map.empty[Token, (Reference, Order[Tradable])]
+    val outstandingOrders = Map.empty[OrderId, (OrderReferenceId, Order[Tradable])]
     new SingleUnitSeller(issuer, outstandingOrders, valuations)
   }
 

--- a/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitSeller.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitSeller.scala
@@ -18,15 +18,15 @@ package org.economicsl.auctions.singleunit.participants
 import java.util.UUID
 
 import org.economicsl.auctions._
-import org.economicsl.auctions.messages.{AuctionDataRequest, AuctionDataResponse}
+import org.economicsl.auctions.messages.{AuctionDataRequest, AuctionDataResponse, OrderId, OrderReferenceId}
 import org.economicsl.auctions.singleunit.orders.SingleUnitAskOrder
 import org.economicsl.core.{Price, Tradable}
 
 
 class SingleUnitSeller private(
-                                val issuer: Issuer,
-                                val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
-                                val valuations: Map[Tradable, Price])
+  val issuer: Issuer,
+  val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+  val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
 

--- a/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitSeller.scala
+++ b/src/functional/scala/org/economicsl/auctions/singleunit/participants/SingleUnitSeller.scala
@@ -24,9 +24,9 @@ import org.economicsl.core.{Price, Tradable}
 
 
 class SingleUnitSeller private(
-  val issuer: Issuer,
-  val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
-  val valuations: Map[Tradable, Price])
+                                val participantId: Issuer,
+                                val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+                                val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
 
@@ -48,7 +48,7 @@ class SingleUnitSeller private(
     */
   def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitSeller,(OrderId, SingleUnitAskOrder[T]))] = {
     val valuation = valuations(protocol.tradable)
-    Some((this, (randomOrderId(), SingleUnitAskOrder(issuer, valuation, protocol.tradable))))
+    Some((this, (randomOrderId(), SingleUnitAskOrder(participantId, valuation, protocol.tradable))))
   }
 
   /** Request auction data given some `AuctionProtocol`.
@@ -63,12 +63,12 @@ class SingleUnitSeller private(
 
   /** Creates a new `SingleUnitSeller` with an `updated` collection of outstanding orders. */
   protected def withOutstandingOrders(updated: Map[OrderId, (OrderReferenceId, Order[Tradable])]): SingleUnitSeller = {
-    new SingleUnitSeller(issuer, updated, valuations)
+    new SingleUnitSeller(participantId, updated, valuations)
   }
 
   /** Creates a new `SingleUnitSeller` with `updated` valuations. */
   protected def withValuations(updated: Map[Tradable, Price]): SingleUnitSeller = {
-    new SingleUnitSeller(issuer, outstandingOrders, updated)
+    new SingleUnitSeller(participantId, outstandingOrders, updated)
   }
 
 }

--- a/src/main/scala/org/economicsl/auctions/AuctionParticipant.scala
+++ b/src/main/scala/org/economicsl/auctions/AuctionParticipant.scala
@@ -26,7 +26,7 @@ import org.economicsl.core.{Price, Tradable}
   * @since 0.2.0
   */
 trait AuctionParticipant[+P <: AuctionParticipant[P]]
-    extends TokenGenerator {
+    extends OrderIdGenerator[P] {
   this: P =>
 
   /** Returns a new `AuctionParticipant` ...
@@ -68,7 +68,7 @@ trait AuctionParticipant[+P <: AuctionParticipant[P]]
     * @return
     */
   final def handle(canceled: Canceled): P = {
-    val updated = outstandingOrders - canceled.issuer
+    val updated = outstandingOrders - canceled.orderId
     withOutstandingOrders(updated)
   }
 
@@ -88,7 +88,7 @@ trait AuctionParticipant[+P <: AuctionParticipant[P]]
     * @tparam T
     * @return
     */
-  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(P, (Token, Order[T]))]
+  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(P, (OrderId, Order[T]))]
 
   /** Each `AuctionParticipant` needs to request auction data given some `AuctionProtocol`.
     *
@@ -96,16 +96,16 @@ trait AuctionParticipant[+P <: AuctionParticipant[P]]
     * @tparam T
     * @return
     */
-  def requestAuctionData[T <: Tradable](protocol: AuctionProtocol[T]): Option[(P, (Token, AuctionDataRequest[T]))]
+  def requestAuctionData[T <: Tradable](protocol: AuctionProtocol[T]): Option[(P, (OrderId, AuctionDataRequest[T]))]
 
   /** An `AuctionParticipant` needs to keep track of its previously issued `Order` instances. */
-  def outstandingOrders: Map[Token, (Reference, Order[Tradable])]
+  def outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])]
 
   /** An `AuctionParticipant` needs to keep track of its valuations for each `Tradable`. */
   def valuations: Map[Tradable, Price]
 
   /** Factory method used to delegate instance creation to sub-classes. */
-  protected def withOutstandingOrders(updated: Map[Token, (Reference, Order[Tradable])]): P
+  protected def withOutstandingOrders(updated: Map[OrderId, (OrderReferenceId, Order[Tradable])]): P
 
   /** Factory method used to delegate instance creation to sub-classes. */
   protected def withValuations(updated: Map[Tradable, Price]): P

--- a/src/main/scala/org/economicsl/auctions/AuctionParticipant.scala
+++ b/src/main/scala/org/economicsl/auctions/AuctionParticipant.scala
@@ -80,7 +80,7 @@ trait AuctionParticipant[+P <: AuctionParticipant[P]]
   def handle[T <: Tradable](auctionDataResponse: AuctionDataResponse[T]): P
 
   /** Each `AuctionParticipant` needs to be uniquely identified. */
-  def issuer: Issuer
+  def participantId: SenderId
 
   /** Each `AuctionParticipant` needs to issue orders given some `AuctionProtocol`.
     *

--- a/src/main/scala/org/economicsl/auctions/Order.scala
+++ b/src/main/scala/org/economicsl/auctions/Order.scala
@@ -1,3 +1,18 @@
+/*
+Copyright (c) 2017 KAPSARC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package org.economicsl.auctions
 
 import org.economicsl.core.Tradable

--- a/src/main/scala/org/economicsl/auctions/OrderIdGenerator.scala
+++ b/src/main/scala/org/economicsl/auctions/OrderIdGenerator.scala
@@ -13,19 +13,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package org.economicsl
+package org.economicsl.auctions
 
-import java.util.UUID
+import org.economicsl.auctions.messages.OrderId
+import org.economicsl.core.util.UUIDGenerator
 
 
-/** General documentation for the auctions package should go here! */
-package object auctions {
+/** Mixin trait providing `OrderId` methods for generating `OrderId` instances.
+  *
+  * @tparam P
+  * @author davidrpugh
+  * @since 0.2.0
+  */
+trait OrderIdGenerator[+P <: AuctionParticipant[P]]
+    extends UUIDGenerator {
+  this: P =>
 
-  type Buyer = UUID
-
-  type Seller = UUID
-
-  /* Type alias used to denote a unique identifier for each auction participant. */
-  type Issuer = UUID
+  protected def randomOrderId(): OrderId = {
+    randomUUID()
+  }
 
 }

--- a/src/main/scala/org/economicsl/auctions/OrderReferenceIdGenerator.scala
+++ b/src/main/scala/org/economicsl/auctions/OrderReferenceIdGenerator.scala
@@ -15,14 +15,27 @@ limitations under the License.
 */
 package org.economicsl.auctions
 
+
+import org.economicsl.auctions.messages.OrderReferenceId
+import org.economicsl.auctions.singleunit.Auction
+import org.economicsl.core.Tradable
 import org.economicsl.core.util.UUIDGenerator
 
 
-trait TokenGenerator
-  extends UUIDGenerator {
+/** Mixin trait providing methods for generating OrderRId` instances.
+  *
+  * @tparam A
+  * @author davidrpugh
+  * @since 0.2.0
+  */
+trait OrderReferenceIdGenerator[T <: Tradable, A <: Auction[T, A]]
+    extends UUIDGenerator {
+  this: A =>
 
-  protected def randomToken(): Token = {
+  protected def randomOrderReferenceId(): OrderReferenceId = {
     randomUUID()
   }
 
 }
+
+

--- a/src/main/scala/org/economicsl/auctions/actors/AuctionActor.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/AuctionActor.scala
@@ -45,8 +45,8 @@ trait AuctionActor[T <: Tradable, A <: Auction[T, A]]
   this: ClearingSchedule[T, A] =>
 
   override def receive: Receive = {
-    case message @ InsertOrder(_, token, order: SingleUnitOrder[T]) =>
-      val (updatedAuction, response) = auction.insert(token -> order)
+    case message @ InsertOrder(order: SingleUnitOrder[T], orderId, _, _) =>
+      val (updatedAuction, response) = auction.insert(orderId -> order)
       response match {
         case Right(accepted) =>
           sender() ! accepted

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/ClearingSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/ClearingSchedule.scala
@@ -55,7 +55,7 @@ trait BidderActivityClearingSchedule[T <: Tradable, A <: Auction[T, A]]
   this: AuctionActor[T, A] =>
 
   override def receive: Receive = {
-    case message @ InsertOrder(_, _, _: SingleUnitOrder[T]) =>
+    case message @ InsertOrder(_: SingleUnitOrder[T], _, _, _) =>
       settlementService match {
         case Some(actorRef) =>
           val (clearedAuction, results) = auction.clear

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/OrderCancellationSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/OrderCancellationSchedule.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.actors.schedules
 
 import org.economicsl.auctions.actors.{AuctionParticipantActor, StackableActor}
-import org.economicsl.auctions.messages.{CancelOrder, SenderId}
+import org.economicsl.auctions.messages.CancelOrder
 import org.economicsl.auctions.AuctionParticipant
 import org.economicsl.core.Tradable
 

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/OrderCancellationSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/OrderCancellationSchedule.scala
@@ -59,7 +59,7 @@ trait PeriodicOrderCancellationSchedule[P <: AuctionParticipant[P]]
       val cancelledOrder = participant.outstandingOrders.headOption
       cancelledOrder.foreach {
         case (orderId, (orderRefId, order)) =>
-          val senderId: SenderId = ???
+          val senderId = participant.participantId
           val orderCancellation = CancelOrder(orderRefId, senderId, currentTimeMillis())
           val auctionActorRef = auctionActorRefsByTradable(order.tradable)
           auctionActorRef ! orderCancellation

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/OrderCancellationSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/OrderCancellationSchedule.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.actors.schedules
 
 import org.economicsl.auctions.actors.{AuctionParticipantActor, StackableActor}
-import org.economicsl.auctions.messages.CancelOrder
+import org.economicsl.auctions.messages.{CancelOrder, SenderId}
 import org.economicsl.auctions.AuctionParticipant
 import org.economicsl.core.Tradable
 
@@ -58,8 +58,9 @@ trait PeriodicOrderCancellationSchedule[P <: AuctionParticipant[P]]
     case IssueOrderCancellation =>
       val cancelledOrder = participant.outstandingOrders.headOption
       cancelledOrder.foreach {
-        case (token, (reference, order)) =>
-          val orderCancellation = CancelOrder(reference, currentTimeMillis(), token)
+        case (orderId, (orderRefId, order)) =>
+          val senderId: SenderId = ???
+          val orderCancellation = CancelOrder(orderRefId, senderId, currentTimeMillis())
           val auctionActorRef = auctionActorRefsByTradable(order.tradable)
           auctionActorRef ! orderCancellation
       }

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/OrderIssuingSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/OrderIssuingSchedule.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.actors.schedules
 
 import org.economicsl.auctions.actors.{AuctionParticipantActor, StackableActor}
-import org.economicsl.auctions.messages.{InsertOrder, SenderId}
+import org.economicsl.auctions.messages.InsertOrder
 import org.economicsl.auctions.{AuctionParticipant, AuctionProtocol}
 import org.economicsl.core.Tradable
 
@@ -54,7 +54,7 @@ trait PeriodicOrderIssuingSchedule[P <: AuctionParticipant[P]]
       issuedOrder match {
         case Some((updated, (orderId, order))) =>
           participant = updated  // SIDE EFFECT!!
-          val senderId: SenderId = ???
+          val senderId = participant.issuer
           val insertOrder = InsertOrder(order, orderId, senderId, currentTimeMillis())
           auctionActorRefsByTradable.get(protocol.tradable).foreach(auction => auction ! insertOrder)
         case None =>

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/OrderIssuingSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/OrderIssuingSchedule.scala
@@ -54,7 +54,7 @@ trait PeriodicOrderIssuingSchedule[P <: AuctionParticipant[P]]
       issuedOrder match {
         case Some((updated, (orderId, order))) =>
           participant = updated  // SIDE EFFECT!!
-          val senderId = participant.issuer
+          val senderId = participant.participantId
           val insertOrder = InsertOrder(order, orderId, senderId, currentTimeMillis())
           auctionActorRefsByTradable.get(protocol.tradable).foreach(auction => auction ! insertOrder)
         case None =>

--- a/src/main/scala/org/economicsl/auctions/actors/schedules/OrderIssuingSchedule.scala
+++ b/src/main/scala/org/economicsl/auctions/actors/schedules/OrderIssuingSchedule.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.actors.schedules
 
 import org.economicsl.auctions.actors.{AuctionParticipantActor, StackableActor}
-import org.economicsl.auctions.messages.InsertOrder
+import org.economicsl.auctions.messages.{InsertOrder, SenderId}
 import org.economicsl.auctions.{AuctionParticipant, AuctionProtocol}
 import org.economicsl.core.Tradable
 
@@ -52,9 +52,10 @@ trait PeriodicOrderIssuingSchedule[P <: AuctionParticipant[P]]
     case message @ IssueOrder(protocol) =>
       val issuedOrder = participant.issueOrder(protocol)
       issuedOrder match {
-        case Some((updated, (token, order))) =>
+        case Some((updated, (orderId, order))) =>
           participant = updated  // SIDE EFFECT!!
-          val insertOrder = InsertOrder(currentTimeMillis(), token, order)
+          val senderId: SenderId = ???
+          val insertOrder = InsertOrder(order, orderId, senderId, currentTimeMillis())
           auctionActorRefsByTradable.get(protocol.tradable).foreach(auction => auction ! insertOrder)
         case None =>
           // if no order is issued then there should be nothing to do!

--- a/src/main/scala/org/economicsl/auctions/messages/Accepted.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/Accepted.scala
@@ -1,25 +1,43 @@
+/*
+Copyright (c) 2017 KAPSARC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package org.economicsl.auctions.messages
 
-import org.economicsl.auctions.{Order, Reference, Token}
+import org.economicsl.auctions.Order  // messages should not depend on auctions!
 import org.economicsl.core.Tradable
 import org.economicsl.core.util.Timestamp
 
 
 /** Message used to indicate that a previously submitted order was accepted.
   *
+  * @param order
+  * @param orderId the unique (to the `AuctionParticipant`) identifier of the previously accepted order.
+  * @param orderRefId the unique (to the auction) reference number assigned to the order at the time of receipt.
+  * @param senderId
   * @param timestamp
-  * @param issuer the unique (to the `AuctionParticipant`) identifier of the previously accepted order.
-  * @param order the previously submitted order that has been accepted.
-  * @param reference A unique (to the auction) reference number assigned to the order at the time of receipt.
   * @author davidrpugh
   * @since 0.2.0
   */
 final case class Accepted(
-                           timestamp: Timestamp,
-                           issuer: Token, order: Order[Tradable],
-                           reference: Reference)
-  extends Message {
+  order: Order[Tradable],
+  orderId: OrderId,
+  orderRefId: OrderReferenceId,
+  senderId: SenderId,
+  timestamp: Timestamp)
+    extends Message {
 
-  val kv: (Token, (Reference, Order[Tradable])) = issuer -> (reference -> order)
+  val kv: (OrderId, (OrderReferenceId, Order[Tradable])) = orderId -> (orderRefId -> order)
 
 }

--- a/src/main/scala/org/economicsl/auctions/messages/AuctionDataResponse.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/AuctionDataResponse.scala
@@ -28,9 +28,9 @@ import org.economicsl.core.util.Timestamp
   * @author davidrpugh
   * @since 0.2.0
   */
-case class AuctionDataResponse[+T <: Tradable](
+final case class AuctionDataResponse[+T <: Tradable](
   data: AuctionData[T],
-  issuer: UUID,
+  senderId: SenderId,
   mDReqId: Option[UUID],
   timestamp: Timestamp)
     extends Message

--- a/src/main/scala/org/economicsl/auctions/messages/CancelOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/CancelOrder.scala
@@ -15,8 +15,15 @@ limitations under the License.
 */
 package org.economicsl.auctions.messages
 
-import org.economicsl.auctions.{Reference, Token}
 import org.economicsl.core.util.Timestamp
 
 
-final case class CancelOrder(reference: Reference, timestamp: Timestamp, issuer: Token) extends Message
+/** Message sent from an `AuctionParticipant` to an `Auction` in order to cancel an existing order.
+  *
+  * @param orderRefId
+  * @param senderId
+  * @param timestamp
+  * @author davidrpugh
+  * @since 0.2.0
+  */
+final case class CancelOrder(orderRefId: OrderReferenceId, senderId: OrderId, timestamp: Timestamp) extends Message

--- a/src/main/scala/org/economicsl/auctions/messages/Canceled.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/Canceled.scala
@@ -1,6 +1,21 @@
+/*
+Copyright (c) 2017 KAPSARC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package org.economicsl.auctions.messages
 
-import org.economicsl.auctions.{Order, Token}
+import org.economicsl.auctions.Order  // messages should not depend on auctions!
 import org.economicsl.core.Tradable
 import org.economicsl.core.util.Timestamp
 
@@ -15,6 +30,8 @@ trait Canceled
 
   def order: Order[Tradable]
 
+  def orderId: OrderId
+
   def reason: Reason
 
 }
@@ -22,12 +39,14 @@ trait Canceled
 
 /** Message used to indicate that a previously accepted order has been canceled by its issuer.
   *
+  * @param order
+  * @param orderId
+  * @param senderId
   * @param timestamp
-  * @param issuer the unique (to the `AuctionParticipant`) identifier of the previously accepted order.
   * @author davidrpugh
   * @since 0.2.0
   */
-final case class CanceledByIssuer(timestamp: Timestamp, issuer: Token, order: Order[Tradable])
+final case class CanceledByIssuer(order: Order[Tradable], orderId: OrderId, senderId: SenderId, timestamp: Timestamp)
   extends Canceled {
   val reason: Reason = IssuerRequestedCancel(order)
 }

--- a/src/main/scala/org/economicsl/auctions/messages/InsertOrder.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/InsertOrder.scala
@@ -15,16 +15,20 @@ limitations under the License.
 */
 package org.economicsl.auctions.messages
 
-import org.economicsl.auctions.{Order, Token}
+import org.economicsl.auctions.Order  // auction should depend on messages!
 import org.economicsl.core.Tradable
 import org.economicsl.core.util.Timestamp
 
 
-/**
+/** A message sent from an `AuctionParticipant` to an `Auction` specifying a new order.
   *
-  * @param timestamp
-  * @param issuer
   * @param order
+  * @param orderId
+  * @param senderId
+  * @param timestamp
   * @tparam T
+  * @author davidrpugh
+  * @since 0.2.0
   */
-final case class InsertOrder[+T <: Tradable](timestamp: Timestamp, issuer: Token, order: Order[T]) extends Message
+final case class InsertOrder[+T <: Tradable](order: Order[T], orderId: OrderId, senderId: SenderId, timestamp: Timestamp)
+  extends Message

--- a/src/main/scala/org/economicsl/auctions/messages/Message.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/Message.scala
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package org.economicsl.auctions.messages
 
-import org.economicsl.auctions.Token  // odd dependency on auctions package!
 import org.economicsl.core.util.Timestamp
 
 
@@ -31,7 +30,7 @@ trait Message
   extends Serializable {
 
   /** Unique token identifying the issuer of the message. */
-  def issuer: Token
+  def senderId: SenderId
 
   /** Denotes the time at which the message was sent. */
   def timestamp: Timestamp

--- a/src/main/scala/org/economicsl/auctions/messages/PriceQuoteRequest.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/PriceQuoteRequest.scala
@@ -36,7 +36,7 @@ trait PriceQuoteRequest[T <: Tradable] extends AuctionDataRequest[T]
   * @author davidrpugh
   * @since 0.1.0
   */
-final case class AskPriceQuoteRequest[T <: Tradable](issuer: Issuer, mDReqId: UUID, timestamp: Timestamp)
+final case class AskPriceQuoteRequest[T <: Tradable](senderId: Issuer, mDReqId: UUID, timestamp: Timestamp)
   extends PriceQuoteRequest[T] {
 
   val query: (OpenBidAuction[T]) => AskPriceQuote[T] = {
@@ -51,7 +51,7 @@ final case class AskPriceQuoteRequest[T <: Tradable](issuer: Issuer, mDReqId: UU
   * @author davidrpugh
   * @since 0.1.0
   */
-final case class BidPriceQuoteRequest[T <: Tradable](issuer: Issuer, mDReqId: UUID, timestamp: Timestamp)
+final case class BidPriceQuoteRequest[T <: Tradable](senderId: Issuer, mDReqId: UUID, timestamp: Timestamp)
   extends PriceQuoteRequest[T] {
 
   val query: (OpenBidAuction[T]) => BidPriceQuote[T] = {
@@ -66,7 +66,7 @@ final case class BidPriceQuoteRequest[T <: Tradable](issuer: Issuer, mDReqId: UU
   * @author davidrpugh
   * @since 0.2.0
   */
-final case class MidPointPriceQuoteRequest[T <: Tradable](issuer: Issuer, mDReqId: UUID, timestamp: Timestamp)
+final case class MidPointPriceQuoteRequest[T <: Tradable](senderId: Issuer, mDReqId: UUID, timestamp: Timestamp)
   extends PriceQuoteRequest[T] {
 
   val query: (OpenBidAuction[T]) => MidPointPriceQuote[T] = {

--- a/src/main/scala/org/economicsl/auctions/messages/Rejected.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/Rejected.scala
@@ -1,6 +1,21 @@
+/*
+Copyright (c) 2017 KAPSARC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package org.economicsl.auctions.messages
 
-import org.economicsl.auctions.{Order, Token}
+import org.economicsl.auctions.Order  // auctions should only depend on messages!
 import org.economicsl.core.Tradable
 import org.economicsl.core.util.Timestamp
 
@@ -8,11 +23,11 @@ import org.economicsl.core.util.Timestamp
 /** Message used to indicate that a previously submitted order has been rejected.
   *
   * @param timestamp
-  * @param issuer the unique (to the `AuctionParticipant`) identifier of the previously accepted order.
+  * @param senderId the unique (to the `AuctionParticipant`) identifier of the previously accepted order.
   * @param reason
   * @author davidrpugh
   * @since 0.2.0
   */
-final case class Rejected(timestamp: Timestamp, issuer: Token, order: Order[Tradable], reason: Reason)
+final case class Rejected(timestamp: Timestamp, senderId: OrderId, order: Order[Tradable], reason: Reason)
   extends Message
 

--- a/src/main/scala/org/economicsl/auctions/messages/SenderIdGenerator.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/SenderIdGenerator.scala
@@ -13,19 +13,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package org.economicsl.auctions
-
+package org.economicsl.auctions.messages
 
 import org.economicsl.core.util.UUIDGenerator
 
 
-trait ReferenceGenerator
-    extends UUIDGenerator {
+/** Mixin trait providing methods for generating `SenderId` instances.
+  *
+  * @author davidrpugh
+  * @since 0.2.0
+  */
+trait SenderIdGenerator
+  extends UUIDGenerator {
 
-  protected def randomReference(): Reference = {
+  protected def randomSenderId(): SenderId = {
     randomUUID()
   }
 
 }
-
-

--- a/src/main/scala/org/economicsl/auctions/messages/SpreadQuoteRequest.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/SpreadQuoteRequest.scala
@@ -13,7 +13,7 @@ import org.economicsl.core.util.Timestamp
   * @author davidrpugh
   * @since 0.1.0
   */
-final case class SpreadQuoteRequest[T <: Tradable](issuer: Issuer, mDReqId: UUID, timestamp: Timestamp)
+final case class SpreadQuoteRequest[T <: Tradable](senderId: Issuer, mDReqId: UUID, timestamp: Timestamp)
   extends AuctionDataRequest[T] {
 
   val query: (OpenBidAuction[T]) => SpreadQuote[T] = {

--- a/src/main/scala/org/economicsl/auctions/messages/package.scala
+++ b/src/main/scala/org/economicsl/auctions/messages/package.scala
@@ -26,10 +26,19 @@ import java.util.UUID
   */
 package object messages {
 
+  /* Unique reference identifier for an accepted order as assigned by an `Auction`. */
+  type OrderReferenceId = UUID
+
+  /* Unique identifier for an accepted order as assigned by an `AuctionParticipant`. */
+  type OrderId = UUID
+
   /** Unique reference identifier for the registration details as assigned by the `AuctionActor`. */
   type RegistrationReferenceId = UUID
 
   /** Unique identifier of the registration details as assigned by the `AuctionParticipantActor`. */
   type RegistrationId = UUID
+
+  /** Unique identifier of the sender of a particular `Message`. */
+  type SenderId = UUID
 
 }

--- a/src/main/scala/org/economicsl/auctions/package.scala
+++ b/src/main/scala/org/economicsl/auctions/package.scala
@@ -25,7 +25,4 @@ package object auctions {
 
   type Seller = UUID
 
-  /* Type alias used to denote a unique identifier for each auction participant. */
-  type Issuer = UUID
-
 }

--- a/src/main/scala/org/economicsl/auctions/package.scala
+++ b/src/main/scala/org/economicsl/auctions/package.scala
@@ -25,4 +25,7 @@ package object auctions {
 
   type Seller = UUID
 
+  /* Type alias used to denote a unique identifier for the issuer of an order. */
+  type Issuer = UUID
+
 }

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -103,7 +103,7 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
       (this, Left(rejected))
     case (orderId, order) =>
       val orderRefId = randomOrderReferenceId() // todo would prefer that these not be randomly generated!
-      val senderId: SenderId = ???
+      val senderId = randomSenderId()
       val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
       val accepted = Accepted(order, orderId, orderRefId, senderId, timestamp)
       val updatedOrderBook = orderBook.insert(orderRefId -> kv)

--- a/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/Auction.scala
@@ -34,23 +34,25 @@ import org.economicsl.core.Tradable
   *       each auction implementation.
   */
 trait Auction[T <: Tradable, A <: Auction[T, A]]
-    extends ReferenceGenerator
+    extends OrderReferenceIdGenerator[T, A]
+    with SenderIdGenerator
     with Timestamper {
   this: A =>
 
   /** Create a new instance of type class `A` whose order book contains all previously submitted `BidOrder` instances
     * except the `order`.
     *
-    * @param reference the unique identifier for the order that should be removed.
+    * @param orderRefId the unique identifier for the order that should be removed.
     * @return an instance of type class `A` whose order book contains all previously submitted `BidOrder` instances
     *         except the `order`.
     */
-  def cancel(reference: Reference): (A, Option[Canceled]) = {
-    val (residualOrderBook, removedOrder) = orderBook.remove(reference)
+  def cancel(orderRefId: OrderReferenceId): (A, Option[Canceled]) = {
+    val (residualOrderBook, removedOrder) = orderBook.remove(orderRefId)
     removedOrder match {
-      case Some((token, order)) =>
+      case Some((orderId, order)) =>
+        val senderId = randomSenderId()
         val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
-        val canceled = CanceledByIssuer(timestamp, token, order)
+        val canceled = CanceledByIssuer(order, orderId, senderId, timestamp)
         (withOrderBook(residualOrderBook), Some(canceled))
       case None =>
         (this, None)
@@ -88,22 +90,23 @@ trait Auction[T <: Tradable, A <: Auction[T, A]]
     *         second element is an instance of type class `A` whose order book contains all submitted `BidOrder`
     *         instances.
     */
-  def insert(kv: (Token, SingleUnitOrder[T])): (A, Either[Rejected, Accepted]) = kv match {
-    case (token, order) if order.limit.value % protocol.tickSize > 0 =>
+  def insert(kv: (OrderId, SingleUnitOrder[T])): (A, Either[Rejected, Accepted]) = kv match {
+    case (orderId, order) if order.limit.value % protocol.tickSize > 0 =>
       val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
       val reason = InvalidTickSize(order, protocol)
-      val rejected = Rejected(timestamp, token, order, reason)
+      val rejected = Rejected(timestamp, orderId, order, reason)
       (this, Left(rejected))
-    case (token, order) if !order.tradable.equals(protocol.tradable) =>
+    case (orderId, order) if !order.tradable.equals(protocol.tradable) =>
       val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
       val reason = InvalidTradable(order, protocol)
-      val rejected = Rejected(timestamp, token, order, reason)
+      val rejected = Rejected(timestamp, orderId, order, reason)
       (this, Left(rejected))
-    case (token, order) =>
+    case (orderId, order) =>
+      val orderRefId = randomOrderReferenceId() // todo would prefer that these not be randomly generated!
+      val senderId: SenderId = ???
       val timestamp = currentTimeMillis()  // todo not sure that we want to use real time for timestamps!
-      val reference = randomReference() // todo would prefer that these not be randomly generated!
-      val accepted = Accepted(timestamp, token, order, reference)
-      val updatedOrderBook = orderBook.insert(reference -> kv)
+      val accepted = Accepted(order, orderId, orderRefId, senderId, timestamp)
+      val updatedOrderBook = orderBook.insert(orderRefId -> kv)
       (withOrderBook(updatedOrderBook), Right(accepted))
   }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/orderbooks/UnMatchedOrders.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package org.economicsl.auctions.singleunit.orderbooks
 
-import org.economicsl.auctions.{Reference, Token}
+import org.economicsl.auctions.messages.{OrderId, OrderReferenceId}
 import org.economicsl.auctions.singleunit.orders._
 import org.economicsl.core.{Quantity, Tradable}
 
@@ -36,10 +36,10 @@ final class UnMatchedOrders[T <: Tradable] private(
   require(heapsNotCrossed, "Limit price of best `BidOrder` must not exceed the limit price of the best `AskOrder`.")
 
   /** The ordering used to sort the `AskOrder` instances contained in this `UnMatchedOrders` instance. */
-  val askOrdering: Ordering[(Reference, (Token, SingleUnitAskOrder[T]))] = askOrders.ordering
+  val askOrdering: Ordering[(OrderReferenceId, (OrderId, SingleUnitAskOrder[T]))] = askOrders.ordering
 
   /** The ordering used to sort the `BidOrder` instances contained in this `UnMatchedOrders` instance. */
-  val bidOrdering: Ordering[(Reference, (Token, SingleUnitBidOrder[T]))] = bidOrders.ordering
+  val bidOrdering: Ordering[(OrderReferenceId, (OrderId, SingleUnitBidOrder[T]))] = bidOrders.ordering
 
   /** Total number of units of the `Tradable` contained in the `UnMatchedOrders`. */
   val numberUnits: Quantity = askOrders.numberUnits + bidOrders.numberUnits
@@ -50,25 +50,25 @@ final class UnMatchedOrders[T <: Tradable] private(
     * @return a new `UnMatchedOrders` instance that contains all of the `AskOrder` instances of this instance and that
     *         also contains the `order`.
     */
-  def + (kv: (Reference, (Token, SingleUnitOrder[T]))): UnMatchedOrders[T] = kv match {
-    case (reference, (token, order: SingleUnitAskOrder[T])) =>
-      new UnMatchedOrders(askOrders + (reference -> (token -> order)), bidOrders)
-    case (reference, (token, order: SingleUnitBidOrder[T])) =>
-      new UnMatchedOrders(askOrders, bidOrders + (reference -> (token -> order)))
+  def + (kv: (OrderReferenceId, (OrderId, SingleUnitOrder[T]))): UnMatchedOrders[T] = kv match {
+    case (orderRefId, (orderId, order: SingleUnitAskOrder[T])) =>
+      new UnMatchedOrders(askOrders + (orderRefId -> (orderId -> order)), bidOrders)
+    case (orderRefId, (orderId, order: SingleUnitBidOrder[T])) =>
+      new UnMatchedOrders(askOrders, bidOrders + (orderRefId -> (orderId -> order)))
   }
 
   /** Remove an order from the collection of unmatched orders.
     *
-    * @param reference
+    * @param orderRefId
     * @return a tuple whose first element is ??? and whose second element is ???
     */
-  def - (reference: Reference): (UnMatchedOrders[T], Option[(Token, SingleUnitOrder[T])]) = {
-    val (remainingAskOrders, removedAskOrder) = askOrders - reference
+  def - (orderRefId: OrderReferenceId): (UnMatchedOrders[T], Option[(OrderId, SingleUnitOrder[T])]) = {
+    val (remainingAskOrders, removedAskOrder) = askOrders - orderRefId
     removedAskOrder match {
       case Some(_) =>
         (new UnMatchedOrders(remainingAskOrders, bidOrders), removedAskOrder)
       case None =>
-        val (remainingBidOrders, removedBidOrder) = bidOrders - reference
+        val (remainingBidOrders, removedBidOrder) = bidOrders - orderRefId
         (new UnMatchedOrders(askOrders, remainingBidOrders), removedBidOrder)
     }
   }
@@ -78,13 +78,13 @@ final class UnMatchedOrders[T <: Tradable] private(
     * @param reference the `AskOrder` instance to test for membership.
     * @return `true` if the `order` is contained in this `UnMatchedOrders` instance; `false` otherwise.
     */
-  def contains(reference: Reference): Boolean = askOrders.contains(reference) || bidOrders.contains(reference)
+  def contains(reference: OrderReferenceId): Boolean = askOrders.contains(reference) || bidOrders.contains(reference)
 
-  def get(reference: Reference): Option[(Token, SingleUnitOrder[T])] = {
+  def get(reference: OrderReferenceId): Option[(OrderId, SingleUnitOrder[T])] = {
     askOrders.get(reference).orElse(bidOrders.get(reference))
   }
 
-  def headOption: (Option[(Reference, (Token, SingleUnitAskOrder[T]))], Option[(Reference, (Token, SingleUnitBidOrder[T]))]) = {
+  def headOption: (Option[(OrderReferenceId, (OrderId, SingleUnitAskOrder[T]))], Option[(OrderReferenceId, (OrderId, SingleUnitBidOrder[T]))]) = {
     (askOrders.headOption, bidOrders.headOption)
   }
 

--- a/src/main/scala/org/economicsl/auctions/singleunit/participants/SingleUnitAuctionParticipant.scala
+++ b/src/main/scala/org/economicsl/auctions/singleunit/participants/SingleUnitAuctionParticipant.scala
@@ -1,10 +1,31 @@
+/*
+Copyright (c) 2017 KAPSARC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package org.economicsl.auctions.singleunit.participants
 
+import org.economicsl.auctions.messages.OrderId
 import org.economicsl.auctions.singleunit.orders.SingleUnitOrder
-import org.economicsl.auctions.{AuctionParticipant, AuctionProtocol, Token}
+import org.economicsl.auctions.{AuctionParticipant, AuctionProtocol}
 import org.economicsl.core.Tradable
 
 
+/** Base trait for all `SingleUnitAuctionParticipant` implementations.
+  *
+  * @author davidrpugh
+  * @since 0.2.0
+  */
 trait SingleUnitAuctionParticipant
   extends AuctionParticipant[SingleUnitAuctionParticipant] {
 
@@ -12,9 +33,8 @@ trait SingleUnitAuctionParticipant
     *
     * @param protocol
     * @tparam T
-    * @return a `Tuple2` whose first element contains a `Token` that uniquely identifies an `Order` and whose second
-    *         element is an `Order`.
+    * @return
     */
-  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitAuctionParticipant, (Token, SingleUnitOrder[T]))]
+  def issueOrder[T <: Tradable](protocol: AuctionProtocol[T]): Option[(SingleUnitAuctionParticipant, (OrderId, SingleUnitOrder[T]))]
 
 }

--- a/src/test/scala/org/economicsl/auctions/OrderGenerator.scala
+++ b/src/test/scala/org/economicsl/auctions/OrderGenerator.scala
@@ -17,7 +17,9 @@ package org.economicsl.auctions
 
 import java.util.UUID
 
+import org.economicsl.auctions.messages.OrderId
 import org.economicsl.auctions.singleunit.orders._
+import org.economicsl.core.util.UUIDGenerator
 import org.economicsl.core.{Price, Tradable}
 
 import scala.util.Random
@@ -28,10 +30,10 @@ import scala.util.Random
   * @author davidrpugh
   * @since 0.1.0
   */
-object OrderGenerator extends OrderIdGenerator {
+object OrderGenerator extends UUIDGenerator {
 
   def randomSingleUnitAskOrder[T <: Tradable](tradable: T, prng: Random): (OrderId, SingleUnitAskOrder[T]) = {
-    val token = randomOrderId()
+    val token = randomUUID()
     val issuer = UUID.randomUUID()  // todo make this reproducible!
     val limit = randomPrice(minimum=Price.MinValue, maximum=Price.MaxValue, prng)
     (token, SingleUnitAskOrder(issuer, limit, tradable))
@@ -53,7 +55,7 @@ object OrderGenerator extends OrderIdGenerator {
 
   def randomSingleUnitBidOrder[T <: Tradable](tradable: T, prng: Random): (OrderId, SingleUnitBidOrder[T]) = {
     val issuer = UUID.randomUUID()  // todo make this reproducible!
-    val token = randomOrderId()
+    val token = randomUUID()
     val limit = randomPrice(minimum=Price.MinValue, maximum=Price.MaxValue, prng)
     (token, SingleUnitBidOrder(issuer, limit, tradable))
   }

--- a/src/test/scala/org/economicsl/auctions/OrderGenerator.scala
+++ b/src/test/scala/org/economicsl/auctions/OrderGenerator.scala
@@ -28,19 +28,19 @@ import scala.util.Random
   * @author davidrpugh
   * @since 0.1.0
   */
-object OrderGenerator extends TokenGenerator {
+object OrderGenerator extends OrderIdGenerator {
 
-  def randomSingleUnitAskOrder[T <: Tradable](tradable: T, prng: Random): (Token, SingleUnitAskOrder[T]) = {
-    val token = randomToken()
+  def randomSingleUnitAskOrder[T <: Tradable](tradable: T, prng: Random): (OrderId, SingleUnitAskOrder[T]) = {
+    val token = randomOrderId()
     val issuer = UUID.randomUUID()  // todo make this reproducible!
     val limit = randomPrice(minimum=Price.MinValue, maximum=Price.MaxValue, prng)
     (token, SingleUnitAskOrder(issuer, limit, tradable))
   }
 
 
-  def randomSingleUnitAskOrders[T <: Tradable](n: Int, tradable: T, prng: Random): Stream[(Token, SingleUnitAskOrder[T])] = {
+  def randomSingleUnitAskOrders[T <: Tradable](n: Int, tradable: T, prng: Random): Stream[(OrderId, SingleUnitAskOrder[T])] = {
     @annotation.tailrec
-    def loop(accumulated: Stream[(Token, SingleUnitAskOrder[T])], remaining: Int): Stream[(Token, SingleUnitAskOrder[T])] = {
+    def loop(accumulated: Stream[(OrderId, SingleUnitAskOrder[T])], remaining: Int): Stream[(OrderId, SingleUnitAskOrder[T])] = {
       if (remaining == 0) {
         accumulated
       } else {
@@ -48,19 +48,19 @@ object OrderGenerator extends TokenGenerator {
         loop(ask #:: accumulated, remaining - 1)
       }
     }
-    loop(Stream.empty[(Token, SingleUnitAskOrder[T])], n)
+    loop(Stream.empty[(OrderId, SingleUnitAskOrder[T])], n)
   }
 
-  def randomSingleUnitBidOrder[T <: Tradable](tradable: T, prng: Random): (Token, SingleUnitBidOrder[T]) = {
+  def randomSingleUnitBidOrder[T <: Tradable](tradable: T, prng: Random): (OrderId, SingleUnitBidOrder[T]) = {
     val issuer = UUID.randomUUID()  // todo make this reproducible!
-    val token = randomToken()
+    val token = randomOrderId()
     val limit = randomPrice(minimum=Price.MinValue, maximum=Price.MaxValue, prng)
     (token, SingleUnitBidOrder(issuer, limit, tradable))
   }
 
-  def randomSingleUnitBidOrders[T <: Tradable](n: Int, tradable: T, prng: Random): Stream[(Token, SingleUnitBidOrder[T])] = {
+  def randomSingleUnitBidOrders[T <: Tradable](n: Int, tradable: T, prng: Random): Stream[(OrderId, SingleUnitBidOrder[T])] = {
     @annotation.tailrec
-    def loop(accumulated: Stream[(Token, SingleUnitBidOrder[T])], remaining: Int): Stream[(Token, SingleUnitBidOrder[T])] = {
+    def loop(accumulated: Stream[(OrderId, SingleUnitBidOrder[T])], remaining: Int): Stream[(OrderId, SingleUnitBidOrder[T])] = {
       if (remaining == 0) {
         accumulated
       } else {
@@ -68,11 +68,11 @@ object OrderGenerator extends TokenGenerator {
         loop(bid #:: accumulated, remaining - 1)
       }
     }
-    loop(Stream.empty[(Token, SingleUnitBidOrder[T])], n)
+    loop(Stream.empty[(OrderId, SingleUnitBidOrder[T])], n)
   }
 
 
-  def randomSingleUnitOrder[T <: Tradable](askOrderProbability: Double)(tradable: T, prng: Random): (Token, SingleUnitOrder[T]) = {
+  def randomSingleUnitOrder[T <: Tradable](askOrderProbability: Double)(tradable: T, prng: Random): (OrderId, SingleUnitOrder[T]) = {
     if (prng.nextDouble() <= askOrderProbability) {
       randomSingleUnitAskOrder(tradable, prng)
     } else {
@@ -81,9 +81,9 @@ object OrderGenerator extends TokenGenerator {
   }
 
 
-  def randomSingleUnitOrders[T <: Tradable](askOrderProbability: Double)(n: Int, tradable: T, prng: Random): Stream[(Token, SingleUnitOrder[T])] = {
+  def randomSingleUnitOrders[T <: Tradable](askOrderProbability: Double)(n: Int, tradable: T, prng: Random): Stream[(OrderId, SingleUnitOrder[T])] = {
     @annotation.tailrec
-    def loop(accumulated: Stream[(Token, SingleUnitOrder[T])], remaining: Int): Stream[(Token, SingleUnitOrder[T])] = {
+    def loop(accumulated: Stream[(OrderId, SingleUnitOrder[T])], remaining: Int): Stream[(OrderId, SingleUnitOrder[T])] = {
       if (remaining == 0) {
         accumulated
       } else {
@@ -91,7 +91,7 @@ object OrderGenerator extends TokenGenerator {
         loop(order #:: accumulated, remaining - 1)
       }
     }
-    loop(Stream.empty[(Token, SingleUnitOrder[T])], n)
+    loop(Stream.empty[(OrderId, SingleUnitOrder[T])], n)
   }
 
 

--- a/src/test/scala/org/economicsl/auctions/actors/AuctionParticipantActorSpec.scala
+++ b/src/test/scala/org/economicsl/auctions/actors/AuctionParticipantActorSpec.scala
@@ -15,15 +15,13 @@ limitations under the License.
 */
 package org.economicsl.auctions.actors
 
-import java.util.UUID
-
 import akka.actor.ActorSystem
 import akka.testkit.{TestActorRef, TestKit}
 import org.economicsl.auctions.messages.{Accepted, CanceledByIssuer}
-import org.economicsl.auctions.{OrderReferenceIdGenerator, TestTradable, OrderIdGenerator}
+import org.economicsl.auctions.TestTradable
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.core.{Price, Tradable}
-import org.economicsl.core.util.Timestamper
+import org.economicsl.core.util.{Timestamper, UUIDGenerator}
 import org.scalatest.{FeatureSpecLike, GivenWhenThen, Matchers}
 
 import scala.util.Random
@@ -34,9 +32,8 @@ class AuctionParticipantActorSpec
     with FeatureSpecLike
     with GivenWhenThen
     with Matchers
-    with OrderReferenceIdGenerator
-    with Timestamper
-    with OrderIdGenerator {
+    with UUIDGenerator
+    with Timestamper {
 
   val tradable = TestTradable()
 
@@ -48,7 +45,7 @@ class AuctionParticipantActorSpec
 
     val prng = new Random(42)
     val askOrderProbability = 0.5
-    val issuer = UUID.randomUUID()
+    val issuer = randomUUID()
     val valuations = Map.empty[Tradable, Price]
     val props = TestAuctionParticipantActor.props(prng, askOrderProbability, issuer, valuations)
     val auctionParticipantActorRef = TestActorRef[TestAuctionParticipantActor](props)
@@ -58,16 +55,17 @@ class AuctionParticipantActorSpec
 
       When("an AuctionParticipantActor receives an Accepted message")
 
-      val token = randomOrderId()
+      val orderId = randomUUID()
       val order = SingleUnitBidOrder(issuer, Price(10), tradable)
 
       val timestamp = currentTimeMillis()
-      val reference = randomOrderReferenceId()
-      auctionParticipantActorRef ! Accepted(timestamp, token, order, reference)
+      val orderRefId = randomUUID()
+      val senderId = randomUUID()
+      auctionParticipantActorRef ! Accepted(order, orderId, orderRefId, senderId, timestamp)
 
       Then("the AuctionParticipantActor should add the accepted order to its collection of outstanding orders.")
 
-      auctionParticipantActor.participant.outstandingOrders.get(token) should be(Some((reference, order)))
+      auctionParticipantActor.participant.outstandingOrders.get(orderId) should be(Some((orderRefId, order)))
 
     }
 
@@ -77,7 +75,7 @@ class AuctionParticipantActorSpec
 
     val prng = new Random(42)
     val askOrderProbability = 0.5
-    val issuer = UUID.randomUUID()
+    val issuer = randomUUID()
     val valuations = Map.empty[Tradable, Price]
     val props = TestAuctionParticipantActor.props(prng, askOrderProbability, issuer, valuations)
     val auctionParticipantActorRef = TestActorRef[TestAuctionParticipantActor](props)
@@ -87,21 +85,22 @@ class AuctionParticipantActorSpec
 
       Given("that an AuctionParticipantActor has already had at least one order accepted")
 
-      val token = randomOrderId()
+      val orderId = randomUUID()
       val order = SingleUnitAskOrder(issuer, Price(137), tradable)
 
       val timestamp = currentTimeMillis()
-      val reference = randomOrderReferenceId()
-      auctionParticipantActorRef ! Accepted(timestamp, token, order, reference)
+      val orderRefId = randomUUID()
+      val senderId = randomUUID()
+      auctionParticipantActorRef ! Accepted(order, orderId, orderRefId, senderId, timestamp)
 
       When("that AuctionParticipantActor receives a Canceled message for one of its previously accepted orders")
 
       val laterTimestamp = currentTimeMillis()
-      auctionParticipantActorRef ! CanceledByIssuer(laterTimestamp, token, order)
+      auctionParticipantActorRef ! CanceledByIssuer(order, orderId, senderId, laterTimestamp)
 
       Then("that AuctionParticipantActor should remove the canceled order from its collection of outstanding orders.")
 
-      auctionParticipantActor.participant.outstandingOrders.get(token) should be(None)
+      auctionParticipantActor.participant.outstandingOrders.get(orderId) should be(None)
 
     }
 

--- a/src/test/scala/org/economicsl/auctions/actors/AuctionParticipantActorSpec.scala
+++ b/src/test/scala/org/economicsl/auctions/actors/AuctionParticipantActorSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.testkit.{TestActorRef, TestKit}
 import org.economicsl.auctions.messages.{Accepted, CanceledByIssuer}
-import org.economicsl.auctions.{ReferenceGenerator, TestTradable, TokenGenerator}
+import org.economicsl.auctions.{OrderReferenceIdGenerator, TestTradable, OrderIdGenerator}
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.core.{Price, Tradable}
 import org.economicsl.core.util.Timestamper
@@ -34,9 +34,9 @@ class AuctionParticipantActorSpec
     with FeatureSpecLike
     with GivenWhenThen
     with Matchers
-    with ReferenceGenerator
+    with OrderReferenceIdGenerator
     with Timestamper
-    with TokenGenerator {
+    with OrderIdGenerator {
 
   val tradable = TestTradable()
 
@@ -58,11 +58,11 @@ class AuctionParticipantActorSpec
 
       When("an AuctionParticipantActor receives an Accepted message")
 
-      val token = randomToken()
+      val token = randomOrderId()
       val order = SingleUnitBidOrder(issuer, Price(10), tradable)
 
       val timestamp = currentTimeMillis()
-      val reference = randomReference()
+      val reference = randomOrderReferenceId()
       auctionParticipantActorRef ! Accepted(timestamp, token, order, reference)
 
       Then("the AuctionParticipantActor should add the accepted order to its collection of outstanding orders.")
@@ -87,11 +87,11 @@ class AuctionParticipantActorSpec
 
       Given("that an AuctionParticipantActor has already had at least one order accepted")
 
-      val token = randomToken()
+      val token = randomOrderId()
       val order = SingleUnitAskOrder(issuer, Price(137), tradable)
 
       val timestamp = currentTimeMillis()
-      val reference = randomReference()
+      val reference = randomOrderReferenceId()
       auctionParticipantActorRef ! Accepted(timestamp, token, order, reference)
 
       When("that AuctionParticipantActor receives a Canceled message for one of its previously accepted orders")

--- a/src/test/scala/org/economicsl/auctions/singleunit/TestSingleUnitAuctionParticipant.scala
+++ b/src/test/scala/org/economicsl/auctions/singleunit/TestSingleUnitAuctionParticipant.scala
@@ -30,16 +30,16 @@ import scala.util.Random
   *
   * @param prng a pseudo-random number generator.
   * @param askOrderProbability probability that the `TestOrderIssuer` generates a `SingleLimitAskOrder`.
-  * @param issuer
+  * @param participantId
   * @param outstandingOrders
   * @param valuations
   */
 class TestSingleUnitAuctionParticipant private(
- prng: Random,
- askOrderProbability: Double,
- val issuer: Issuer,
- val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
- val valuations: Map[Tradable, Price])
+                                                prng: Random,
+                                                askOrderProbability: Double,
+                                                val participantId: Issuer,
+                                                val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+                                                val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
 
@@ -66,13 +66,13 @@ class TestSingleUnitAuctionParticipant private(
       val valuation = valuations.getOrElse(protocol.tradable, Price.MinValue)
       val remainder = valuation.value % protocol.tickSize
       val limit = if (valuation.isMultipleOf(protocol.tickSize)) valuation else Price(valuation.value + (protocol.tickSize - remainder))
-      Some((this, (randomOrderId(), SingleUnitAskOrder(issuer, limit, protocol.tradable))))
+      Some((this, (randomOrderId(), SingleUnitAskOrder(participantId, limit, protocol.tradable))))
     } else {
       // if valuation is not multiple of tick size, price is largest multiple of tick size less than valuation.
       val valuation = valuations.getOrElse(protocol.tradable, Price.MaxValue)
       val remainder = valuation.value % protocol.tickSize
       val limit = if (valuation.isMultipleOf(protocol.tickSize)) valuation else Price(valuation.value - remainder)
-      Some((this, (randomOrderId(), SingleUnitBidOrder(issuer, limit, protocol.tradable))))
+      Some((this, (randomOrderId(), SingleUnitBidOrder(participantId, limit, protocol.tradable))))
     }
   }
 
@@ -89,12 +89,12 @@ class TestSingleUnitAuctionParticipant private(
 
   /** Factory method used by sub-classes to create an `A`. */
   protected def withOutstandingOrders(updated: Map[OrderId, (OrderReferenceId, Order[Tradable])]): TestSingleUnitAuctionParticipant = {
-    new TestSingleUnitAuctionParticipant(prng, askOrderProbability, issuer, updated, valuations)
+    new TestSingleUnitAuctionParticipant(prng, askOrderProbability, participantId, updated, valuations)
   }
 
   /** Factory method used to delegate instance creation to sub-classes. */
   protected def withValuations(updated: Map[Tradable, Price]): TestSingleUnitAuctionParticipant = {
-    new TestSingleUnitAuctionParticipant(prng, askOrderProbability, issuer, outstandingOrders, updated)
+    new TestSingleUnitAuctionParticipant(prng, askOrderProbability, participantId, outstandingOrders, updated)
   }
 
 }

--- a/src/test/scala/org/economicsl/auctions/singleunit/TestSingleUnitAuctionParticipant.scala
+++ b/src/test/scala/org/economicsl/auctions/singleunit/TestSingleUnitAuctionParticipant.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package org.economicsl.auctions.singleunit
 
 import org.economicsl.auctions._
-import org.economicsl.auctions.messages.{AuctionDataRequest, AuctionDataResponse}
+import org.economicsl.auctions.messages.{AuctionDataRequest, AuctionDataResponse, OrderId, OrderReferenceId}
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder, SingleUnitOrder}
 import org.economicsl.auctions.singleunit.participants.SingleUnitAuctionParticipant
 import org.economicsl.core.{Price, Tradable}
@@ -35,11 +35,11 @@ import scala.util.Random
   * @param valuations
   */
 class TestSingleUnitAuctionParticipant private(
-                                                prng: Random,
-                                                askOrderProbability: Double,
-                                                val issuer: Issuer,
-                                                val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
-                                                val valuations: Map[Tradable, Price])
+ prng: Random,
+ askOrderProbability: Double,
+ val issuer: Issuer,
+ val outstandingOrders: Map[OrderId, (OrderReferenceId, Order[Tradable])],
+ val valuations: Map[Tradable, Price])
     extends SingleUnitAuctionParticipant {
 
 

--- a/src/test/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBookSpec.scala
@@ -16,8 +16,10 @@ limitations under the License.
 package org.economicsl.auctions.singleunit.orderbooks
 
 import org.economicsl.auctions._
+import org.economicsl.auctions.messages.{OrderId, OrderReferenceId}
 import org.economicsl.auctions.singleunit.orders.{SingleUnitAskOrder, SingleUnitBidOrder}
 import org.economicsl.core.Quantity
+import org.economicsl.core.util.UUIDGenerator
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
@@ -31,16 +33,16 @@ import scala.util.Random
 class FourHeapOrderBookSpec
     extends FlatSpec
     with Matchers
-    with OrderReferenceIdGenerator {
+    with UUIDGenerator {
 
   val tradable = TestTradable()
 
   val numberBids = 100
-  val bidReferences: Iterable[OrderReferenceId] = for (i <- 0 until numberBids) yield randomOrderReferenceId()
+  val bidReferences: Iterable[OrderReferenceId] = for (i <- 0 until numberBids) yield randomUUID()
   val bids: Stream[(OrderId, SingleUnitBidOrder[TestTradable])] = OrderGenerator.randomSingleUnitBidOrders(numberBids, tradable, new Random(42))
 
   val numberOffers = 100
-  val offerReferences: Iterable[OrderReferenceId] = for (i <- 0 until numberOffers) yield randomOrderReferenceId()
+  val offerReferences: Iterable[OrderReferenceId] = for (i <- 0 until numberOffers) yield randomUUID()
   val offers: Stream[(OrderId, SingleUnitAskOrder[TestTradable])] = OrderGenerator.randomSingleUnitAskOrders(numberOffers, tradable, new Random(42))
 
   val initial: FourHeapOrderBook[TestTradable] = FourHeapOrderBook.empty[TestTradable]

--- a/src/test/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBookSpec.scala
+++ b/src/test/scala/org/economicsl/auctions/singleunit/orderbooks/FourHeapOrderBookSpec.scala
@@ -31,17 +31,17 @@ import scala.util.Random
 class FourHeapOrderBookSpec
     extends FlatSpec
     with Matchers
-    with ReferenceGenerator {
+    with OrderReferenceIdGenerator {
 
   val tradable = TestTradable()
 
   val numberBids = 100
-  val bidReferences: Iterable[Reference] = for (i <- 0 until numberBids) yield randomReference()
-  val bids: Stream[(Token, SingleUnitBidOrder[TestTradable])] = OrderGenerator.randomSingleUnitBidOrders(numberBids, tradable, new Random(42))
+  val bidReferences: Iterable[OrderReferenceId] = for (i <- 0 until numberBids) yield randomOrderReferenceId()
+  val bids: Stream[(OrderId, SingleUnitBidOrder[TestTradable])] = OrderGenerator.randomSingleUnitBidOrders(numberBids, tradable, new Random(42))
 
   val numberOffers = 100
-  val offerReferences: Iterable[Reference] = for (i <- 0 until numberOffers) yield randomReference()
-  val offers: Stream[(Token, SingleUnitAskOrder[TestTradable])] = OrderGenerator.randomSingleUnitAskOrders(numberOffers, tradable, new Random(42))
+  val offerReferences: Iterable[OrderReferenceId] = for (i <- 0 until numberOffers) yield randomOrderReferenceId()
+  val offers: Stream[(OrderId, SingleUnitAskOrder[TestTradable])] = OrderGenerator.randomSingleUnitAskOrders(numberOffers, tradable, new Random(42))
 
   val initial: FourHeapOrderBook[TestTradable] = FourHeapOrderBook.empty[TestTradable]
   val withBids: FourHeapOrderBook[TestTradable] = bidReferences.zip(bids).foldLeft(initial){


### PR DESCRIPTION
Now using `OrderId` instead of `Token` and `OrderReferenceId` instead of `Reference` to indicate unique ids  for orders provided by auction participants and auctions, respectively.  Also took first steps towards breaking dependency between `messages` package and 'auctions' package.  The `auctions` library should depend on the `messages` package but not the other way round.  This will allow me to extract the messaging protocol out into a separate repository where it can be developed separately.